### PR TITLE
Add DecodeToObject<T> overload with a byte[] key

### DIFF
--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -191,23 +191,37 @@ namespace JWT
             var payloadJson = JsonWebToken.Decode(token, key, verify);
             var payloadData = JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
             return payloadData;
-        }
+		}
 
-        /// <summary>
-        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>An object representing the payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static T DecodeToObject<T>(string token, string key, bool verify = true)
-        {
-            var payloadJson = JsonWebToken.Decode(token, key, verify);
-            var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
-            return payloadData;
-        }
+		/// <summary>
+		/// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+		/// </summary>
+		/// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+		/// <param name="token">The JWT.</param>
+		/// <param name="key">The key that was used to sign the JWT.</param>
+		/// <param name="verify">Whether to verify the signature (default is true).</param>
+		/// <returns>An object representing the payload.</returns>
+		/// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+		public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
+		{
+			var payloadJson = JsonWebToken.Decode(token, key, verify);
+			var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
+			return payloadData;
+		}
+
+		/// <summary>
+		/// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+		/// </summary>
+		/// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+		/// <param name="token">The JWT.</param>
+		/// <param name="key">The key that was used to sign the JWT.</param>
+		/// <param name="verify">Whether to verify the signature (default is true).</param>
+		/// <returns>An object representing the payload.</returns>
+		/// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+		public static T DecodeToObject<T>(string token, string key, bool verify = true)
+		{
+			return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
+		}
 
         private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)
         {

--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -191,37 +191,37 @@ namespace JWT
             var payloadJson = JsonWebToken.Decode(token, key, verify);
             var payloadData = JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
             return payloadData;
-		}
+        }
 
-		/// <summary>
-		/// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-		/// </summary>
-		/// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
-		/// <param name="token">The JWT.</param>
-		/// <param name="key">The key that was used to sign the JWT.</param>
-		/// <param name="verify">Whether to verify the signature (default is true).</param>
-		/// <returns>An object representing the payload.</returns>
-		/// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-		public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
-		{
-			var payloadJson = JsonWebToken.Decode(token, key, verify);
-			var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
-			return payloadData;
-		}
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
+        {
+            var payloadJson = JsonWebToken.Decode(token, key, verify);
+            var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
+            return payloadData;
+        }
 
-		/// <summary>
-		/// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-		/// </summary>
-		/// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
-		/// <param name="token">The JWT.</param>
-		/// <param name="key">The key that was used to sign the JWT.</param>
-		/// <param name="verify">Whether to verify the signature (default is true).</param>
-		/// <returns>An object representing the payload.</returns>
-		/// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-		public static T DecodeToObject<T>(string token, string key, bool verify = true)
-		{
-			return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
-		}
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        public static T DecodeToObject<T>(string token, string key, bool verify = true)
+        {
+            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
+        }
 
         private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)
         {

--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -186,11 +186,24 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static object DecodeToObject(string token, string key, bool verify = true)
+        public static object DecodeToObject(string token, byte[] key, bool verify = true)
         {
             var payloadJson = JsonWebToken.Decode(token, key, verify);
             var payloadData = JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
             return payloadData;
+        }
+
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        public static object DecodeToObject(string token, string key, bool verify = true)
+        {
+            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), verify);
         }
 
         /// <summary>


### PR DESCRIPTION
A simple addition that makes the `DecodeToObject` API consistent with the regular `Decode` one.