### PR TITLE
Add support for nbf (Not Before) token claim validation

### DIFF
--- a/JWT.Tests/DecodeTests.cs
+++ b/JWT.Tests/DecodeTests.cs
@@ -150,6 +150,8 @@ namespace JWT.Tests
         [TestMethod]
         public void Should_Decode_Token_After_NotBefore_Token_Becomes_Valid()
         {
+            var nowUtc = DateTime.UtcNow;
+            Int32 unixTimestamp = (Int32)(nowUtc.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
             var validnbftoken = JsonWebToken.Encode(new { nbf = unixTimestamp }, "ABC", JwtHashAlgorithm.HS256);
 

--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -173,6 +173,25 @@ namespace JWT
                     throw new SignatureVerificationException("Token has expired.");
                 }
             }
+            // verify nbf claim https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.5
+            if (payloadData.ContainsKey("nbf") && payloadData["nbf"] != null)
+            {
+                int nbf;
+                try
+                {
+                    nbf = Convert.ToInt32(payloadData["nbf"]);
+                }
+                catch (Exception)
+                {
+                    throw new SignatureVerificationException("Claim 'nbf' must be an integer.");
+                }
+
+                var secondsSinceEpoch = Math.Round((DateTime.UtcNow - UnixEpoch).TotalSeconds);
+                if (secondsSinceEpoch < nbf)
+                {
+                    throw new SignatureVerificationException("Token is not yet valid.");
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added code and tests to support validation of 'nbf' claims in payload per section 4.1.5 of the JWT specification.
