### PR TITLE
String "keys" lead to inconsistent (possibly unintended) results:

### DIFF
--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace JWT
 {
@@ -10,6 +12,30 @@ namespace JWT
         HS256,
         HS384,
         HS512
+    }
+
+    public static class Extensions
+    {
+        private static readonly Regex HEX_SANITY =
+            new Regex(@"^[0-9a-fA-F]+$");
+
+        public static byte[] FromHex(this string hex)
+        {
+            if (0 != (hex.Length % 2))
+                throw new ArgumentOutOfRangeException(
+                    "A hex string should be an even number of characters");
+            else if(!HEX_SANITY.IsMatch(hex))
+                throw new ArgumentOutOfRangeException(
+                    "Hexadecimal numbers consists only of the digits 0-9 " +
+                    "and the letters a-z");
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                for (int i = 0; i < hex.Length; i += 2)
+                    ms.WriteByte((Convert.ToByte(hex.Substring(i, 2), 16)));
+                return ms.ToArray();
+            }
+        }
     }
 
     /// <summary>
@@ -91,7 +117,7 @@ namespace JWT
         /// <returns>The generated JWT.</returns>
         public static string Encode(IDictionary<string, object> extraHeaders, object payload, string key, JwtHashAlgorithm algorithm)
         {
-            return Encode(extraHeaders, payload, Encoding.UTF8.GetBytes(key), algorithm);
+            return Encode(extraHeaders, payload, key.FromHex(), algorithm);
         }
 
         /// <summary>
@@ -103,7 +129,7 @@ namespace JWT
         /// <returns>The generated JWT.</returns>
         public static string Encode(object payload, string key, JwtHashAlgorithm algorithm)
         {
-            return Encode(new Dictionary<string, object>(), payload, Encoding.UTF8.GetBytes(key), algorithm);
+            return Encode(new Dictionary<string, object>(), payload, key.FromHex(), algorithm);
         }
 
         /// <summary>
@@ -185,7 +211,7 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         public static string Decode(string token, string key, bool verify = true)
         {
-            return Decode(token, Encoding.UTF8.GetBytes(key), verify);
+            return Decode(token, key.FromHex(), verify);
         }
 
         /// <summary>
@@ -213,7 +239,7 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         public static object DecodeToObject(string token, string key, bool verify = true)
         {
-            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), verify);
+            return DecodeToObject(token, key.FromHex(), verify);
         }
 
         /// <summary>
@@ -243,7 +269,7 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         public static T DecodeToObject<T>(string token, string key, bool verify = true)
         {
-            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
+            return DecodeToObject<T>(token, key.FromHex(), verify);
         }
 
         private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)


### PR DESCRIPTION
Consider ensuring that the methods accepting a string "key" accept only a hexadecimal string and then decode that string directly to the bytes said hexadecmial characters represent.  Or possibly consider removing the Encode/Decode methods that accept a string parameter for a key.

HMACSHA256 algorithms generally take an array of bytes as the data to be signed as well as another array of bytes as the key.

In this JWT implementation the `Encoding.UTF8.GetBytes(key)` call will simply convert the string to its UTF8 character bytes.  For example,

```csharp
Encoding.UTF8.GetBytes("0123456789abcdef") ==
    byte[]
    {
        0x30, 0x31, 0x32, 0x33,
        0x34, 0x35, 0x36, 0x37,
        0x38, 0x39, 0x61, 0x62,
        0x63, 0x64, 0x65, 0x66 // 16 bytes
    }

```

and

```csharp
Encoding.UTF8.GetBytes("0123456789ABCDEF") ==
    byte[]
    {
        0x30, 0x31, 0x32, 0x33,
        0x34, 0x35, 0x36, 0x37,
        0x38, 0x39, 0x41, 0x42,
        0x43, 0x44, 0x45, 0x46 // 16 bytes
    }
```

Where as

```csharp
"0123456789abcdef".FromHex() ==
    byte[]
    {
        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef // only 8 bytes
    }
```

and

```csharp
"0123456789ABCDEF".FromHex() ==
    byte[]
    {
        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef // only 8 bytes
    }
```

Not only does the `Encoding.UTF8.GetBytes()` method above lead to double the intended length byte array it also makes the hexadecimal string value case sensitive:   A hexadecimal `"a"` and a hexadecimal `"A"` both represent a decimal value of `"10"`.  However, a UTF8 character `"a"` represents a hexadecimal value of `0x61` whereas a UTF8 character character `"A"` represents a hexadecimal value of `0x41`.
