### PR TITLE
Addressed issue #43 should provide algorithm when decoding/verifying.

### DIFF
--- a/JWT.Tests/DecodeTests.cs
+++ b/JWT.Tests/DecodeTests.cs
@@ -26,7 +26,7 @@ namespace JWT.Tests
             var jsonSerializer = new JavaScriptSerializer();
             var expectedPayload = jsonSerializer.Serialize(customer);
 
-            string decodedPayload = JsonWebToken.Decode(token, "ABC", false);
+            string decodedPayload = JsonWebToken.Decode(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             Assert.AreEqual(expectedPayload, decodedPayload);
         }
@@ -34,7 +34,7 @@ namespace JWT.Tests
         [TestMethod]
         public void Should_Decode_Token_To_Dictionary()
         {
-            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", false);
+            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(dictionaryPayload, options => options.IncludingAllRuntimeProperties());
         }
@@ -44,7 +44,7 @@ namespace JWT.Tests
         {
             JsonWebToken.JsonSerializer = new ServiceStackJsonSerializer();
 
-            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", false);
+            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(dictionaryPayload, options => options.IncludingAllRuntimeProperties());
         }
@@ -54,7 +54,7 @@ namespace JWT.Tests
         {
             JsonWebToken.JsonSerializer = new NewtonJsonSerializer();
 
-            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", false);
+            object decodedPayload = JsonWebToken.DecodeToObject(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(dictionaryPayload, options => options.IncludingAllRuntimeProperties());
         }
@@ -62,7 +62,7 @@ namespace JWT.Tests
         [TestMethod]
         public void Should_Decode_Token_To_Generic_Type()
         {
-            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", false);
+            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(customer);
         }
@@ -72,7 +72,7 @@ namespace JWT.Tests
         {
             JsonWebToken.JsonSerializer = new ServiceStackJsonSerializer();
 
-            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", false);
+            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(customer);
         }
@@ -82,7 +82,7 @@ namespace JWT.Tests
         {
             JsonWebToken.JsonSerializer = new NewtonJsonSerializer();
 
-            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", false);
+            Customer decodedPayload = JsonWebToken.DecodeToObject<Customer>(token, "ABC", JwtHashAlgorithm.HS256, false);
 
             decodedPayload.ShouldBeEquivalentTo(customer);
         }
@@ -91,7 +91,7 @@ namespace JWT.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void Should_Throw_On_Malformed_Token()
         {
-            JsonWebToken.DecodeToObject<Customer>(malformedtoken, "ABC", false);
+            JsonWebToken.DecodeToObject<Customer>(malformedtoken, "ABC", JwtHashAlgorithm.HS256, false);
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace JWT.Tests
         {
             string invalidkey = "XYZ";
 
-            JsonWebToken.DecodeToObject<Customer>(token, invalidkey, true);
+            JsonWebToken.DecodeToObject<Customer>(token, invalidkey, JwtHashAlgorithm.HS256, true);
         }
 
         [TestMethod]
@@ -109,7 +109,7 @@ namespace JWT.Tests
         {
             var invalidexptoken = JsonWebToken.Encode(new { exp = "asdsad" }, "ABC", JwtHashAlgorithm.HS256);
 
-            JsonWebToken.DecodeToObject<Customer>(invalidexptoken, "ABC", true);
+            JsonWebToken.DecodeToObject<Customer>(invalidexptoken, "ABC", JwtHashAlgorithm.HS256, true);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace JWT.Tests
 
             var invalidexptoken = JsonWebToken.Encode(new { exp = unixTimestamp }, "ABC", JwtHashAlgorithm.HS256);
 
-            JsonWebToken.DecodeToObject<Customer>(invalidexptoken, "ABC", true);
+            JsonWebToken.DecodeToObject<Customer>(invalidexptoken, "ABC", JwtHashAlgorithm.HS256, true);
         }
     }
 

--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -114,7 +114,7 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>A string containing the JSON payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static string Decode(string token, byte[] key, bool verify = true)
+        public static string Decode(string token, byte[] key, JwtHashAlgorithm algorithm, bool verify = true)
         {
             var parts = token.Split('.');
             if (parts.Length != 3)
@@ -133,9 +133,7 @@ namespace JWT
             if (verify)
             {
                 var bytesToSign = Encoding.UTF8.GetBytes(string.Concat(header, ".", payload));
-                var algorithm = (string)headerData["alg"];
-
-                var signature = HashAlgorithms[GetHashAlgorithm(algorithm)](key, bytesToSign);
+                var signature = HashAlgorithms[algorithm](key, bytesToSign);
                 var decodedCrypto = Convert.ToBase64String(crypto);
                 var decodedSignature = Convert.ToBase64String(signature);
 
@@ -183,9 +181,9 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>A string containing the JSON payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static string Decode(string token, string key, bool verify = true)
+        public static string Decode(string token, string key, JwtHashAlgorithm algorithm, bool verify = true)
         {
-            return Decode(token, Encoding.UTF8.GetBytes(key), verify);
+            return Decode(token, Encoding.UTF8.GetBytes(key), algorithm, verify);
         }
 
         /// <summary>
@@ -196,9 +194,9 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static object DecodeToObject(string token, byte[] key, bool verify = true)
+        public static object DecodeToObject(string token, byte[] key, JwtHashAlgorithm algorithm, bool verify = true)
         {
-            var payloadJson = Decode(token, key, verify);
+            var payloadJson = Decode(token, key, algorithm, verify);
             var payloadData = JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
             return payloadData;
         }
@@ -211,9 +209,9 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static object DecodeToObject(string token, string key, bool verify = true)
+        public static object DecodeToObject(string token, string key, JwtHashAlgorithm algorithm, bool verify = true)
         {
-            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), verify);
+            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), algorithm, verify);
         }
 
         /// <summary>
@@ -225,9 +223,9 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
+        public static T DecodeToObject<T>(string token, byte[] key, JwtHashAlgorithm algorithm, bool verify = true)
         {
-            var payloadJson = Decode(token, key, verify);
+            var payloadJson = Decode(token, key, algorithm, verify);
             var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
             return payloadData;
         }
@@ -241,9 +239,9 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        public static T DecodeToObject<T>(string token, string key, bool verify = true)
+        public static T DecodeToObject<T>(string token, string key, JwtHashAlgorithm algorithm, bool verify = true)
         {
-            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
+            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), algorithm, verify);
         }
 
         private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)


### PR DESCRIPTION
This pr addresses https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/ - however it is an interface breaking change. That said, it's a very small breaking change, and simple to resolve.
