### PR TITLE
Ordering overloads of Encode() and Decode(). Moving private methods to the bottom

### DIFF
--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace JWT
 {
-	/// <summary>
+    /// <summary>
     /// Provides methods for encoding and decoding JSON Web Tokens.
     /// </summary>
     public static class JsonWebToken
@@ -27,6 +27,43 @@ namespace JWT
                 { JwtHashAlgorithm.HS384, (key, value) => { using (var sha = new HMACSHA384(key)) { return sha.ComputeHash(value); } } },
                 { JwtHashAlgorithm.HS512, (key, value) => { using (var sha = new HMACSHA512(key)) { return sha.ComputeHash(value); } } }
             };
+        }
+
+        /// <summary>
+        /// Creates a JWT given a payload, the signing key, and the algorithm to use.
+        /// </summary>
+        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
+        /// <param name="key">The key used to sign the token.</param>
+        /// <param name="algorithm">The hash algorithm to use.</param>
+        /// <returns>The generated JWT.</returns>
+        public static string Encode(object payload, string key, JwtHashAlgorithm algorithm)
+        {
+            return Encode(new Dictionary<string, object>(), payload, Encoding.UTF8.GetBytes(key), algorithm);
+        }
+
+        /// <summary>
+        /// Creates a JWT given a payload, the signing key, and the algorithm to use.
+        /// </summary>
+        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
+        /// <param name="key">The key used to sign the token.</param>
+        /// <param name="algorithm">The hash algorithm to use.</param>
+        /// <returns>The generated JWT.</returns>
+        public static string Encode(object payload, byte[] key, JwtHashAlgorithm algorithm)
+        {
+            return Encode(new Dictionary<string, object>(), payload, key, algorithm);
+        }
+
+        /// <summary>
+        /// Creates a JWT given a set of arbitrary extra headers, a payload, the signing key, and the algorithm to use.
+        /// </summary>
+        /// <param name="extraHeaders">An arbitrary set of extra headers. Will be augmented with the standard "typ" and "alg" headers.</param>
+        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
+        /// <param name="key">The key bytes used to sign the token.</param>
+        /// <param name="algorithm">The hash algorithm to use.</param>
+        /// <returns>The generated JWT.</returns>
+        public static string Encode(IDictionary<string, object> extraHeaders, object payload, string key, JwtHashAlgorithm algorithm)
+        {
+            return Encode(extraHeaders, payload, Encoding.UTF8.GetBytes(key), algorithm);
         }
 
         /// <summary>
@@ -62,40 +99,17 @@ namespace JWT
         }
 
         /// <summary>
-        /// Creates a JWT given a payload, the signing key, and the algorithm to use.
+        /// Given a JWT, decode it and return the JSON payload.
         /// </summary>
-        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
-        /// <param name="key">The key used to sign the token.</param>
-        /// <param name="algorithm">The hash algorithm to use.</param>
-        /// <returns>The generated JWT.</returns>
-        public static string Encode(object payload, byte[] key, JwtHashAlgorithm algorithm)
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>A string containing the JSON payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        public static string Decode(string token, string key, bool verify = true)
         {
-            return Encode(new Dictionary<string, object>(), payload, key, algorithm);
-        }
-
-        /// <summary>
-        /// Creates a JWT given a set of arbitrary extra headers, a payload, the signing key, and the algorithm to use.
-        /// </summary>
-        /// <param name="extraHeaders">An arbitrary set of extra headers. Will be augmented with the standard "typ" and "alg" headers.</param>
-        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
-        /// <param name="key">The key bytes used to sign the token.</param>
-        /// <param name="algorithm">The hash algorithm to use.</param>
-        /// <returns>The generated JWT.</returns>
-        public static string Encode(IDictionary<string, object> extraHeaders, object payload, string key, JwtHashAlgorithm algorithm)
-        {
-            return Encode(extraHeaders, payload, Encoding.UTF8.GetBytes(key), algorithm);
-        }
-
-        /// <summary>
-        /// Creates a JWT given a payload, the signing key, and the algorithm to use.
-        /// </summary>
-        /// <param name="payload">An arbitrary payload (must be serializable to JSON via <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).</param>
-        /// <param name="key">The key used to sign the token.</param>
-        /// <param name="algorithm">The hash algorithm to use.</param>
-        /// <returns>The generated JWT.</returns>
-        public static string Encode(object payload, string key, JwtHashAlgorithm algorithm)
-        {
-            return Encode(new Dictionary<string, object>(), payload, Encoding.UTF8.GetBytes(key), algorithm);
+            return Decode(token, Encoding.UTF8.GetBytes(key), verify);
         }
 
         /// <summary>
@@ -138,6 +152,104 @@ namespace JWT
             return payloadJson;
         }
 
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        public static object DecodeToObject(string token, string key, bool verify = true)
+        {
+            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), verify);
+        }
+
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        public static object DecodeToObject(string token, byte[] key, bool verify = true)
+        {
+            var payloadJson = Decode(token, key, verify);
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
+        }
+
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        public static T DecodeToObject<T>(string token, string key, bool verify = true)
+        {
+            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
+        }
+
+        /// <summary>
+        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="key">The key that was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
+        {
+            var payloadJson = Decode(token, key, verify);
+            return JsonSerializer.Deserialize<T>(payloadJson);
+        }
+
+        /// <remarks>From JWT spec</remarks>
+        public static string Base64UrlEncode(byte[] input)
+        {
+            var output = Convert.ToBase64String(input);
+            output = output.Split('=')[0]; // Remove any trailing '='s
+            output = output.Replace('+', '-'); // 62nd char of encoding
+            output = output.Replace('/', '_'); // 63rd char of encoding
+            return output;
+        }
+
+        /// <remarks>From JWT spec</remarks>
+        public static byte[] Base64UrlDecode(string input)
+        {
+            var output = input;
+            output = output.Replace('-', '+'); // 62nd char of encoding
+            output = output.Replace('_', '/'); // 63rd char of encoding
+            switch (output.Length % 4) // Pad with trailing '='s
+            {
+                case 0: break; // No pad chars in this case
+                case 2: output += "=="; break; // Two pad chars
+                case 3: output += "="; break;  // One pad char
+                default: throw new FormatException("Illegal base64url string!");
+            }
+            var converted = Convert.FromBase64String(output); // Standard base64 decoder
+            return converted;
+        }
+
+        private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)
+        {
+            switch (algorithm)
+            {
+                case "HS256": return JwtHashAlgorithm.HS256;
+                case "HS384": return JwtHashAlgorithm.HS384;
+                case "HS512": return JwtHashAlgorithm.HS512;
+                default: throw new SignatureVerificationException("Algorithm not supported.");
+            }
+        }
+
         private static void Verify(string decodedCrypto, string decodedSignature, string payloadJson)
         {
             if (decodedCrypto != decodedSignature)
@@ -166,120 +278,6 @@ namespace JWT
             {
                 throw new TokenExpiredException("Token has expired.");
             }
-        }
-
-        /// <summary>
-        /// Given a JWT, decode it and return the JSON payload.
-        /// </summary>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>A string containing the JSON payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        public static string Decode(string token, string key, bool verify = true)
-        {
-            return Decode(token, Encoding.UTF8.GetBytes(key), verify);
-        }
-
-        /// <summary>
-        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-        /// </summary>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>An object representing the payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        public static object DecodeToObject(string token, byte[] key, bool verify = true)
-        {
-            var payloadJson = Decode(token, key, verify);
-            var payloadData = JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
-            return payloadData;
-        }
-
-        /// <summary>
-        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-        /// </summary>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>An object representing the payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        public static object DecodeToObject(string token, string key, bool verify = true)
-        {
-            return DecodeToObject(token, Encoding.UTF8.GetBytes(key), verify);
-        }
-
-        /// <summary>
-        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>An object representing the payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        public static T DecodeToObject<T>(string token, byte[] key, bool verify = true)
-        {
-            var payloadJson = Decode(token, key, verify);
-            var payloadData = JsonSerializer.Deserialize<T>(payloadJson);
-            return payloadData;
-        }
-
-        /// <summary>
-        /// Given a JWT, decode it and return the payload as an object (by deserializing it with <see cref="System.Web.Script.Serialization.JavaScriptSerializer"/>).
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
-        /// <param name="token">The JWT.</param>
-        /// <param name="key">The key that was used to sign the JWT.</param>
-        /// <param name="verify">Whether to verify the signature (default is true).</param>
-        /// <returns>An object representing the payload.</returns>
-        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
-        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        public static T DecodeToObject<T>(string token, string key, bool verify = true)
-        {
-            return DecodeToObject<T>(token, Encoding.UTF8.GetBytes(key), verify);
-        }
-
-        private static JwtHashAlgorithm GetHashAlgorithm(string algorithm)
-        {
-            switch (algorithm)
-            {
-                case "HS256": return JwtHashAlgorithm.HS256;
-                case "HS384": return JwtHashAlgorithm.HS384;
-                case "HS512": return JwtHashAlgorithm.HS512;
-                default: throw new SignatureVerificationException("Algorithm not supported.");
-            }
-        }
-
-        // from JWT spec
-        public static string Base64UrlEncode(byte[] input)
-        {
-            var output = Convert.ToBase64String(input);
-            output = output.Split('=')[0]; // Remove any trailing '='s
-            output = output.Replace('+', '-'); // 62nd char of encoding
-            output = output.Replace('/', '_'); // 63rd char of encoding
-            return output;
-        }
-
-        // from JWT spec
-        public static byte[] Base64UrlDecode(string input)
-        {
-            var output = input;
-            output = output.Replace('-', '+'); // 62nd char of encoding
-            output = output.Replace('_', '/'); // 63rd char of encoding
-            switch (output.Length % 4) // Pad with trailing '='s
-            {
-                case 0: break; // No pad chars in this case
-                case 2: output += "=="; break; // Two pad chars
-                case 3: output += "="; break;  // One pad char
-                default: throw new FormatException("Illegal base64url string!");
-            }
-            var converted = Convert.FromBase64String(output); // Standard base64 decoder
-            return converted;
         }
     }
 }


### PR DESCRIPTION
According to the [Member Overloading](https://msdn.microsoft.com/en-us/library/ms229029(v=vs.110).aspx) guidance.