### PR TITLE
Downgrading target framework version to .NET 3.5

### DIFF
--- a/JWT.nuspec
+++ b/JWT.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>JWT</id>
-    <version>2.1.0-beta</version>
+    <version>2.2.0-beta</version>
     <authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</authors>
     <owners>johnsheehan, devinrader, abatishchev</owners>
     <description>Jwt.Net, a JWT (JSON Web Token) implementation for .NET</description>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JWT</RootNamespace>
     <AssemblyName>JWT</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/JWT/JsonWebToken.cs
+++ b/src/JWT/JsonWebToken.cs
@@ -19,7 +19,7 @@ namespace JWT
         /// </summary>
         public static IJsonSerializer JsonSerializer = new JsonNetSerializer();
 
-        private static readonly Lazy<IJwtValidator> _jwtValidator = new Lazy<IJwtValidator>(() => new JwtValidator(JsonSerializer, new UtcDateTimeProvider()));
+        private static readonly IJwtValidator _jwtValidator = new JwtValidator(JsonSerializer, new UtcDateTimeProvider());
 
         private static readonly AlgorithmFactory _algorithmFactory = new AlgorithmFactory();
 
@@ -103,7 +103,7 @@ namespace JWT
         {
             return new JwtDecoder(
                 JsonSerializer,
-                _jwtValidator.Value)
+                _jwtValidator)
                     .Decode(token, key, verify);
         }
 
@@ -177,7 +177,7 @@ namespace JWT
         /// <exception cref="TokenExpiredException">The token has expired.</exception>
         public static void Verify(string payloadJson, string decodedCrypto, string decodedSignature)
         {
-            _jwtValidator.Value.Validate(payloadJson, decodedCrypto, decodedSignature);
+            _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
         }
 
         /// <remarks>From JWT spec</remarks>

--- a/src/JWT/packages.config
+++ b/src/JWT/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
- Setting TargetFrameworkVersion to v3.5
- Stopping using `Lazy<T>`
- Bumping nuget version to 2.2.0-beta