### PR TITLE
Moving Base64UrlEncode/Base64UrlDecode to separate entity

### DIFF
--- a/package.cmd
+++ b/package.cmd
@@ -3,9 +3,9 @@
 if not exist package mkdir package
 if not exist package mkdir package
 if not exist package\lib mkdir package\lib
-if not exist package\lib\net35 mkdir package\lib\net35
+if not exist package\lib\net45 mkdir package\lib\net45
 
 msbuild src\JWT.sln -p:Configuration=Release
-copy src\JWT\bin\Release\JWT.dll package\lib\net35
+copy src\JWT\bin\Release\JWT.dll package\lib\net45
 
 tools\nuget.exe pack JWT.nuspec -BasePath package

--- a/package.cmd
+++ b/package.cmd
@@ -3,9 +3,9 @@
 if not exist package mkdir package
 if not exist package mkdir package
 if not exist package\lib mkdir package\lib
-if not exist package\lib\net45 mkdir package\lib\net45
+if not exist package\lib\net35 mkdir package\lib\net35
 
 msbuild src\JWT.sln -p:Configuration=Release
-copy src\JWT\bin\Release\JWT.dll package\lib\net45
+copy src\JWT\bin\Release\JWT.dll package\lib\net35
 
 tools\nuget.exe pack JWT.nuspec -BasePath package

--- a/src/JWT/IBase64UrlEncoder.cs
+++ b/src/JWT/IBase64UrlEncoder.cs
@@ -2,8 +2,8 @@ namespace JWT
 {
     public interface IBase64UrlEncoder
     {
-        string UrlEncode(byte[] input);
+        string Encode(byte[] input);
 
-        byte[] UrlDecode(string input);
+        byte[] Decode(string input);
     }
 }

--- a/src/JWT/IBase64UrlEncoder.cs
+++ b/src/JWT/IBase64UrlEncoder.cs
@@ -1,0 +1,9 @@
+namespace JWT
+{
+    public interface IBase64UrlEncoder
+    {
+        string UrlEncode(byte[] input);
+
+        byte[] UrlDecode(string input);
+    }
+}

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Algorithms\HMACSHA384Algorithm.cs" />
     <Compile Include="Algorithms\HMACSHA512Algorithm.cs" />
     <Compile Include="Algorithms\RS256Algorithm.cs" />
+    <Compile Include="IBase64UrlEncoder.cs" />
     <Compile Include="IDateTimeProvider.cs" />
     <Compile Include="IJsonSerializer.cs" />
     <Compile Include="IJwtAlgorithm.cs" />
@@ -55,6 +56,7 @@
     <Compile Include="IJwtEncoder.cs" />
     <Compile Include="IJwtValidator.cs" />
     <Compile Include="JsonWebToken.cs" />
+    <Compile Include="JwtBase64UrlEncoder.cs" />
     <Compile Include="JwtDecoder.cs" />
     <Compile Include="JwtEncoder.cs" />
     <Compile Include="JwtHashAlgorithm.cs" />
@@ -64,9 +66,6 @@
     <Compile Include="SignatureVerificationException.cs" />
     <Compile Include="TokenExpiredException.cs" />
     <Compile Include="UtcDateTimeProvider.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/JWT/JsonWebToken.cs
+++ b/src/JWT/JsonWebToken.cs
@@ -187,13 +187,13 @@ namespace JWT
         /// <remarks>From JWT spec</remarks>
         public static string Base64UrlEncode(byte[] input)
         {
-            return _urlEncoder.UrlEncode(input);
+            return _urlEncoder.Encode(input);
         }
 
         /// <remarks>From JWT spec</remarks>
         public static byte[] Base64UrlDecode(string input)
         {
-            return _urlEncoder.UrlDecode(input);
+            return _urlEncoder.Decode(input);
         }
     }
 }

--- a/src/JWT/JwtBase64UrlEncoder.cs
+++ b/src/JWT/JwtBase64UrlEncoder.cs
@@ -7,7 +7,7 @@ namespace JWT
     /// </summary>
     public sealed class JwtBase64UrlEncoder : IBase64UrlEncoder
     {
-        public string UrlEncode(byte[] input)
+        public string Encode(byte[] input)
         {
             var output = Convert.ToBase64String(input);
             output = output.Split('=')[0]; // Remove any trailing '='s
@@ -16,7 +16,7 @@ namespace JWT
             return output;
         }
 
-        public byte[] UrlDecode(string input)
+        public byte[] Decode(string input)
         {
             var output = input;
             output = output.Replace('-', '+'); // 62nd char of encoding

--- a/src/JWT/JwtBase64UrlEncoder.cs
+++ b/src/JWT/JwtBase64UrlEncoder.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace JWT
+{
+    /// <summary>
+    /// Base64 encoding/decoding implementation according to the JWT spec
+    /// </summary>
+    public sealed class JwtBase64UrlEncoder : IBase64UrlEncoder
+    {
+        public string UrlEncode(byte[] input)
+        {
+            var output = Convert.ToBase64String(input);
+            output = output.Split('=')[0]; // Remove any trailing '='s
+            output = output.Replace('+', '-'); // 62nd char of encoding
+            output = output.Replace('/', '_'); // 63rd char of encoding
+            return output;
+        }
+
+        public byte[] UrlDecode(string input)
+        {
+            var output = input;
+            output = output.Replace('-', '+'); // 62nd char of encoding
+            output = output.Replace('_', '/'); // 63rd char of encoding
+            switch (output.Length % 4) // Pad with trailing '='s
+            {
+                case 0:
+                    break; // No pad chars in this case
+                case 2:
+                    output += "==";
+                    break; // Two pad chars
+                case 3:
+                    output += "=";
+                    break; // One pad char
+                default:
+                    throw new FormatException("Illegal base64url string!");
+            }
+            var converted = Convert.FromBase64String(output); // Standard base64 decoder
+            return converted;
+        }
+    }
+}

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -35,7 +35,7 @@ namespace JWT
             }
 
             var payload = parts[1];
-            var payloadJson = Encoding.UTF8.GetString(_urlEncoder.UrlDecode(payload));
+            var payloadJson = Encoding.UTF8.GetString(_urlEncoder.Decode(payload));
 
             if (verify)
             {
@@ -73,11 +73,11 @@ namespace JWT
 
         private void Validate(string payload, string payloadJson, string[] parts, byte[] key)
         {
-            var crypto = _urlEncoder.UrlDecode(parts[2]);
+            var crypto = _urlEncoder.Decode(parts[2]);
             var decodedCrypto = Convert.ToBase64String(crypto);
 
             var header = parts[0];
-            var headerJson = Encoding.UTF8.GetString(_urlEncoder.UrlDecode(header));
+            var headerJson = Encoding.UTF8.GetString(_urlEncoder.Decode(header));
             var headerData = _jsonSerializer.Deserialize<Dictionary<string, object>>(headerJson);
 
             var bytesToSign = Encoding.UTF8.GetBytes(string.Concat(header, ".", payload));

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -10,11 +10,13 @@ namespace JWT
 
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IJwtValidator _jwtValidator;
+        private readonly IBase64UrlEncoder _urlEncoder;
 
-        public JwtDecoder(IJsonSerializer jsonSerializer, IJwtValidator jwtValidator)
+        public JwtDecoder(IJsonSerializer jsonSerializer, IJwtValidator jwtValidator, IBase64UrlEncoder urlEncoder)
         {
             _jsonSerializer = jsonSerializer;
             _jwtValidator = jwtValidator;
+            _urlEncoder = urlEncoder;
         }
 
         /// <inheritdoc />
@@ -33,7 +35,7 @@ namespace JWT
             }
 
             var payload = parts[1];
-            var payloadJson = Encoding.UTF8.GetString(JsonWebToken.Base64UrlDecode(payload));
+            var payloadJson = Encoding.UTF8.GetString(_urlEncoder.UrlDecode(payload));
 
             if (verify)
             {
@@ -71,11 +73,11 @@ namespace JWT
 
         private void Validate(string payload, string payloadJson, string[] parts, byte[] key)
         {
-            var crypto = JsonWebToken.Base64UrlDecode(parts[2]);
+            var crypto = _urlEncoder.UrlDecode(parts[2]);
             var decodedCrypto = Convert.ToBase64String(crypto);
 
             var header = parts[0];
-            var headerJson = Encoding.UTF8.GetString(JsonWebToken.Base64UrlDecode(header));
+            var headerJson = Encoding.UTF8.GetString(_urlEncoder.UrlDecode(header));
             var headerData = _jsonSerializer.Deserialize<Dictionary<string, object>>(headerJson);
 
             var bytesToSign = Encoding.UTF8.GetBytes(string.Concat(header, ".", payload));

--- a/src/JWT/JwtEncoder.cs
+++ b/src/JWT/JwtEncoder.cs
@@ -46,14 +46,14 @@ namespace JWT
             var headerBytes = Encoding.UTF8.GetBytes(_jsonSerializer.Serialize(header));
             var payloadBytes = Encoding.UTF8.GetBytes(_jsonSerializer.Serialize(payload));
 
-            segments.Add(_urlEncoder.UrlEncode(headerBytes));
-            segments.Add(_urlEncoder.UrlEncode(payloadBytes));
+            segments.Add(_urlEncoder.Encode(headerBytes));
+            segments.Add(_urlEncoder.Encode(payloadBytes));
 
             var stringToSign = string.Join(".", segments.ToArray());
             var bytesToSign = Encoding.UTF8.GetBytes(stringToSign);
 
             var signature = _algorithm.Sign(key, bytesToSign);
-            segments.Add(_urlEncoder.UrlEncode(signature));
+            segments.Add(_urlEncoder.Encode(signature));
 
             return string.Join(".", segments.ToArray());
         }

--- a/src/JWT/JwtEncoder.cs
+++ b/src/JWT/JwtEncoder.cs
@@ -7,11 +7,13 @@ namespace JWT
     {
         private readonly IJwtAlgorithm _algorithm;
         private readonly IJsonSerializer _jsonSerializer;
+        private readonly IBase64UrlEncoder _urlEncoder;
 
-        public JwtEncoder(IJwtAlgorithm algorithm, IJsonSerializer jsonSerializer)
+        public JwtEncoder(IJwtAlgorithm algorithm, IJsonSerializer jsonSerializer, IBase64UrlEncoder urlEncoder)
         {
             _algorithm = algorithm;
             _jsonSerializer = jsonSerializer;
+            _urlEncoder = urlEncoder;
         }
 
         /// <inheritdoc />
@@ -44,14 +46,14 @@ namespace JWT
             var headerBytes = Encoding.UTF8.GetBytes(_jsonSerializer.Serialize(header));
             var payloadBytes = Encoding.UTF8.GetBytes(_jsonSerializer.Serialize(payload));
 
-            segments.Add(JsonWebToken.Base64UrlEncode(headerBytes));
-            segments.Add(JsonWebToken.Base64UrlEncode(payloadBytes));
+            segments.Add(_urlEncoder.UrlEncode(headerBytes));
+            segments.Add(_urlEncoder.UrlEncode(payloadBytes));
 
             var stringToSign = string.Join(".", segments.ToArray());
             var bytesToSign = Encoding.UTF8.GetBytes(stringToSign);
 
             var signature = _algorithm.Sign(key, bytesToSign);
-            segments.Add(JsonWebToken.Base64UrlEncode(signature));
+            segments.Add(_urlEncoder.UrlEncode(signature));
 
             return string.Join(".", segments.ToArray());
         }

--- a/tests/JWT.Tests/JwtDecoderTest.cs
+++ b/tests/JWT.Tests/JwtDecoderTest.cs
@@ -24,7 +24,8 @@ namespace JWT.Tests
         public void Decode_Should_Decode_Token_To_Json_Encoded_String()
         {
             var serializer = new JsonNetSerializer();
-            var decoder = new JwtDecoder(serializer, null);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, null, urlEncoder);
 
             var expectedPayload = serializer.Serialize(_customer);
 
@@ -37,7 +38,8 @@ namespace JWT.Tests
         public void DecodeToObject_Should_Decode_Token_To_Dictionary()
         {
             var serializer = new JsonNetSerializer();
-            var decoder = new JwtDecoder(serializer, null);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, null, urlEncoder);
 
             var actualPayload = decoder.DecodeToObject(_token, "ABC", verify: false);
 
@@ -48,7 +50,8 @@ namespace JWT.Tests
         public void DecodeToObject_Should_Decode_Token_To_Generic_Type()
         {
             var serializer = new JsonNetSerializer();
-            var decoder = new JwtDecoder(serializer, null);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, null, urlEncoder);
 
             var actualPayload = decoder.DecodeToObject<Customer>(_token, "ABC", verify: false);
 
@@ -59,7 +62,8 @@ namespace JWT.Tests
         public void DecodeToObject_Should_Throw_Exception_On_Malformed_Token()
         {
             var serializer = new JsonNetSerializer();
-            var decoder = new JwtDecoder(serializer, null);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, null, urlEncoder);
 
             Action action = () => decoder.DecodeToObject<Customer>(_malformedtoken, "ABC", verify: false);
 
@@ -71,7 +75,8 @@ namespace JWT.Tests
         {
             var serializer = new JsonNetSerializer();
             var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
-            var decoder = new JwtDecoder(serializer, validator);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, validator, urlEncoder);
 
             Action action = () => decoder.DecodeToObject<Customer>(_token, "XYZ", verify: true);
 
@@ -83,9 +88,10 @@ namespace JWT.Tests
         {
             var serializer = new JsonNetSerializer();
             var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
-            var decoder = new JwtDecoder(serializer, validator);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, validator, urlEncoder);
 
-            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer);
+            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
             var invalidtoken = encoder.Encode(new { exp = "asdsad" }, "ABC");
 
             Action action = () => decoder.DecodeToObject<Customer>(invalidtoken, "ABC", verify: true);
@@ -99,13 +105,14 @@ namespace JWT.Tests
             var serializer = new JsonNetSerializer();
             var dateTimeProvider = new UtcDateTimeProvider();
             var validator = new JwtValidator(serializer, dateTimeProvider);
-            var decoder = new JwtDecoder(serializer, validator);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, validator, urlEncoder);
 
             var now = dateTimeProvider.GetNow();
             var hourAgo = now.Subtract(new TimeSpan(1, 0, 0));
             var unixTimestamp = (int)(hourAgo - new DateTime(1970, 1, 1)).TotalSeconds;
 
-            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer);
+            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
             var expiredtoken = encoder.Encode(new { exp = unixTimestamp }, "ABC");
 
             Action action = () => decoder.DecodeToObject<Customer>(expiredtoken, "ABC", verify: true);

--- a/tests/JWT.Tests/JwtEncoderTest.cs
+++ b/tests/JWT.Tests/JwtEncoderTest.cs
@@ -17,7 +17,8 @@ namespace JWT.Tests
         public void Encode_Should_Encode_To_Token()
         {
             var serializer = new JsonNetSerializer();
-            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
 
             var actual = encoder.Encode(_customer, "ABC");
 
@@ -28,7 +29,8 @@ namespace JWT.Tests
         public void Encode_Should_Encode_To_Token_With_Extra_Headers()
         {
             var serializer = new JsonNetSerializer();
-            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer);
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
 
             var extraheaders = new Dictionary<string, object> { { "foo", "bar" } };
             var actual = encoder.Encode(extraheaders, _customer, "ABC");


### PR DESCRIPTION
- Adding IBase64UrlEncoder implemented by JwtBase64UrlEncoder. Calling it from JsonWebToken.Base64UrlEncode/Base64UrlDecode.
- Updating tests