### PR TITLE
Update exp and nbf validation to use double parsing

### DIFF
--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -32,7 +32,6 @@ namespace JWT
 
             var now = _dateTimeProvider.GetNow();
             var secondsSinceEpoch = Math.Round((now - UnixEpoch).TotalSeconds);
-            const string claimMustBeDoubleFormat = "Claim '{0}' must be a double.";
 
             // verify exp claim https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.4
             object expObj;
@@ -40,7 +39,7 @@ namespace JWT
             {
                 if (expObj == null)
                 {
-                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "exp"));
+                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
                 }
 
                 double expInt;
@@ -50,7 +49,7 @@ namespace JWT
                 }
                 catch
                 {
-                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "exp"));
+                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
                 }
 
                 if (secondsSinceEpoch >= expInt)
@@ -69,7 +68,7 @@ namespace JWT
             {
                 if (nbfObj == null)
                 {
-                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "nbf"));
+                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
                 }
 
                 double nbfInt;
@@ -79,7 +78,7 @@ namespace JWT
                 }
                 catch
                 {
-                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "nbf"));
+                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
                 }
 
                 if (secondsSinceEpoch < nbfInt)

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -32,6 +32,7 @@ namespace JWT
 
             var now = _dateTimeProvider.GetNow();
             var secondsSinceEpoch = Math.Round((now - UnixEpoch).TotalSeconds);
+            const string claimMustBeDoubleFormat = "Claim '{0}' must be a double.";
 
             // verify exp claim https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.4
             object expObj;
@@ -39,7 +40,7 @@ namespace JWT
             {
                 if (expObj == null)
                 {
-                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
+                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "exp"));
                 }
 
                 double expInt;
@@ -49,7 +50,7 @@ namespace JWT
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
+                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "exp"));
                 }
 
                 if (secondsSinceEpoch >= expInt)
@@ -68,7 +69,7 @@ namespace JWT
             {
                 if (nbfObj == null)
                 {
-                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
+                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "nbf"));
                 }
 
                 double nbfInt;
@@ -78,7 +79,7 @@ namespace JWT
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
+                    throw new SignatureVerificationException(string.Format(claimMustBeDoubleFormat, "nbf"));
                 }
 
                 if (secondsSinceEpoch < nbfInt)

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -37,10 +37,15 @@ namespace JWT
             object expObj;
             if (payloadData.TryGetValue("exp", out expObj))
             {
+                if (expObj == null)
+                {
+                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
+                }
+
                 double expInt;
                 try
                 {
-                    expInt = double.Parse(expObj.ToString());
+                    expInt = Convert.ToDouble(expObj);
                 }
                 catch
                 {
@@ -61,10 +66,15 @@ namespace JWT
             object nbfObj;
             if (payloadData.TryGetValue("nbf", out nbfObj))
             {
+                if (nbfObj == null)
+                {
+                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
+                }
+
                 double nbfInt;
                 try
                 {
-                    nbfInt = double.Parse(nbfObj.ToString());
+                    nbfInt = Convert.ToDouble(nbfObj);
                 }
                 catch
                 {

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -37,14 +37,14 @@ namespace JWT
             object expObj;
             if (payloadData.TryGetValue("exp", out expObj))
             {
-                int expInt;
+                double expInt;
                 try
                 {
-                    expInt = Convert.ToInt32(expObj);
+                    expInt = double.Parse(expObj.ToString());
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'exp' must be an integer.");
+                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
                 }
 
                 if (secondsSinceEpoch >= expInt)
@@ -61,14 +61,14 @@ namespace JWT
             object nbfObj;
             if (payloadData.TryGetValue("nbf", out nbfObj))
             {
-                int nbfInt;
+                double nbfInt;
                 try
                 {
-                    nbfInt = Convert.ToInt32(nbfObj);
+                    nbfInt = double.Parse(nbfObj.ToString());
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'nbf' must be an integer.");
+                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
                 }
 
                 if (secondsSinceEpoch < nbfInt)

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -39,24 +39,24 @@ namespace JWT
             {
                 if (expObj == null)
                 {
-                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
+                    throw new SignatureVerificationException("Claim 'exp' must be a number.");
                 }
 
-                double expInt;
+                double expValue;
                 try
                 {
-                    expInt = Convert.ToDouble(expObj);
+                    expValue = Convert.ToDouble(expObj);
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'exp' must be a double.");
+                    throw new SignatureVerificationException("Claim 'exp' must be a number.");
                 }
 
-                if (secondsSinceEpoch >= expInt)
+                if (secondsSinceEpoch >= expValue)
                 {
                     throw new TokenExpiredException("Token has expired.")
                     {
-                        Expiration = UnixEpoch.AddSeconds(expInt),
+                        Expiration = UnixEpoch.AddSeconds(expValue),
                         PayloadData = payloadData
                     };
                 }
@@ -68,20 +68,20 @@ namespace JWT
             {
                 if (nbfObj == null)
                 {
-                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
+                    throw new SignatureVerificationException("Claim 'nbf' must be a number.");
                 }
 
-                double nbfInt;
+                double nbfValue;
                 try
                 {
-                    nbfInt = Convert.ToDouble(nbfObj);
+                    nbfValue = Convert.ToDouble(nbfObj);
                 }
                 catch
                 {
-                    throw new SignatureVerificationException("Claim 'nbf' must be a double.");
+                    throw new SignatureVerificationException("Claim 'nbf' must be a number.");
                 }
 
-                if (secondsSinceEpoch < nbfInt)
+                if (secondsSinceEpoch < nbfValue)
                 {
                     throw new SignatureVerificationException("Token is not yet valid.");
                 }

--- a/tests/JWT.Tests.Core/DecodeTests.cs
+++ b/tests/JWT.Tests.Core/DecodeTests.cs
@@ -94,7 +94,8 @@ namespace JWT.Tests
             var serializer = new JsonNetSerializer();
             JsonWebToken.JsonSerializer = serializer;
 
-            var post2038 = new DateTime(3000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            //Why 2038? https://en.wikipedia.org/wiki/Year_2038_problem
+            var post2038 = new DateTime(2038, 1, 19, 3, 14, 8, DateTimeKind.Utc);
             var unixTimestamp = (post2038 - new DateTime(1970, 1, 1)).TotalSeconds;
             var payload = new { exp = unixTimestamp };
             var validToken = JsonWebToken.Encode(payload, "ABC", JwtHashAlgorithm.HS256);
@@ -108,7 +109,7 @@ namespace JWT.Tests
         [Fact]
         public void DecodeToObject_Should_Throw_Exception_Before_NotBefore_Becomes_Valid()
         {
-            var post2038 = new DateTime(3000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var post2038 = new DateTime(2038, 1, 19, 3, 14, 8, DateTimeKind.Utc);
             var nbf = (post2038 - JwtValidator.UnixEpoch).TotalSeconds;
             var invalidnbftoken = JsonWebToken.Encode(new { nbf = nbf }, "ABC", JwtHashAlgorithm.HS256);
 

--- a/tests/JWT.Tests.Core/DecodeTests.cs
+++ b/tests/JWT.Tests.Core/DecodeTests.cs
@@ -73,7 +73,7 @@ namespace JWT.Tests
 
             Action action = () => JsonWebToken.DecodeToObject<Customer>(invalidexptoken, "ABC", verify: true);
 
-            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'exp' must be a double.");
+            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'exp' must be a number.");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace JWT.Tests
 
             Action action = () => JsonWebToken.DecodeToObject<Customer>(invalidnbftoken, "ABC", verify: true);
 
-            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'nbf' must be a double.");
+            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'nbf' must be a number.");
         }
 
         [Fact]

--- a/tests/JWT.Tests.Core/JwtDecoderTest.cs
+++ b/tests/JWT.Tests.Core/JwtDecoderTest.cs
@@ -101,7 +101,7 @@ namespace JWT.Tests
 
             Action action = () => decoder.DecodeToObject<Customer>(invalidtoken, "ABC", verify: true);
 
-            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'exp' must be a double.");
+            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'exp' must be a number.");
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace JWT.Tests
 
             Action action = () => decoder.DecodeToObject<Customer>(invalidnbftoken, "ABC", verify: true);
 
-            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'nbf' must be a double.");
+            action.ShouldThrow<SignatureVerificationException>().WithMessage("Claim 'nbf' must be a number.");
         }
 
         [Fact]


### PR DESCRIPTION
Update exp and nbf validation to be based on strictly-parsed doubles for 2 reasons: Support dates beyond year 2038, and prevent treating nulls as 0.