### PR TITLE
Explicitly specify AppVeyor build image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}
+image: Visual Studio 2017
 build_script:
 - ps: ./build.ps1
 test_script:


### PR DESCRIPTION
Minor fix: I forgot to include this in the original commit of the AppVeyor config. This will pin the AppVeyor build environment to Visual Studio 2017 (which is confirmed working), and will remove the requirement of picking this when setting up AppVeyor.