### PR TITLE
Implementing constant-time comparison in JwtValidator for v2 branch

### DIFF
--- a/JWT.nuspec
+++ b/JWT.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>JWT</id>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
     <authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</authors>
     <owners>johnsheehan, devinrader, abatishchev</owners>
     <description>Jwt.Net, a JWT (JSON Web Token) implementation for .NET</description>

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace JWT
 {
@@ -19,7 +20,7 @@ namespace JWT
         /// <inheritdoc />
         public void Validate(string payloadJson, string decodedCrypto, string decodedSignature)
         {
-            if (decodedCrypto != decodedSignature)
+            if (!CompareCryptoWithSignature(decodedCrypto, decodedSignature))
             {
                 throw new SignatureVerificationException("Invalid signature")
                 {
@@ -76,6 +77,26 @@ namespace JWT
                     throw new SignatureVerificationException("Token is not yet valid.");
                 }
             }
+        }
+
+        /// <remarks>In the future this method can be open for extension so made protected virtual</remarks>
+        private static bool CompareCryptoWithSignature(string decodedCrypto, string decodedSignature)
+        {
+            if (decodedCrypto.Length != decodedSignature.Length)
+            {
+                return false;
+            }
+
+            byte[] decodedCryptoBytes = Encoding.ASCII.GetBytes(decodedCrypto);
+            byte[] decodedSignatureBytes = Encoding.ASCII.GetBytes(decodedSignature);
+
+            byte result = 0;
+            for (int i = 0; i < decodedCrypto.Length; i++)
+            {
+                result |= (byte)(decodedCryptoBytes[i] ^ decodedSignatureBytes[i]);
+            }
+
+            return result == 0;
         }
     }
 }


### PR DESCRIPTION
Back-porting #111

* Implementing constant-time comparison in JwtValidator 
* Bumping nuget version