### PR TITLE
Modify RS256Algorithm to be xplat friendly

### DIFF
--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -27,17 +27,12 @@ namespace JWT.Algorithms
         public byte[] Sign(byte[] key, byte[] bytesToSign)
         {
 #if NETSTANDARD1_3
-            var rsa = (RSACryptoServiceProvider)_cert.GetRSAPrivateKey();
+            var rsa = _cert.GetRSAPrivateKey();
 #else
-            var rsa = (RSACryptoServiceProvider)_cert.PrivateKey;
+            var rsa = _cert.PrivateKey;
 #endif
-            var param = new CspParameters
-            {
-                KeyContainerName = rsa.CspKeyContainerInfo.KeyContainerName,
-                KeyNumber = rsa.CspKeyContainerInfo.KeyNumber == KeyNumber.Exchange ? 1 : 2
-            };
-            var csp = new RSACryptoServiceProvider(param) { PersistKeyInCsp = false };
-            return csp.SignData(bytesToSign, "SHA256");
+
+            return rsa.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 
         /// <summary>

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -28,11 +28,17 @@ namespace JWT.Algorithms
         {
 #if NETSTANDARD1_3
             var rsa = _cert.GetRSAPrivateKey();
-#else
-            var rsa = _cert.PrivateKey;
-#endif
-
             return rsa.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#else
+            var rsa = (RSACryptoServiceProvider)_cert.PrivateKey;
+            var param = new CspParameters
+            {
+                KeyContainerName = rsa.CspKeyContainerInfo.KeyContainerName,
+                KeyNumber = rsa.CspKeyContainerInfo.KeyNumber == KeyNumber.Exchange ? 1 : 2
+            };
+            var csp = new RSACryptoServiceProvider(param) { PersistKeyInCsp = false };
+            return csp.SignData(bytesToSign, "SHA256");
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Use the base class `RSA` for `RS256Algorithm`, which allows use on platforms like macOS and Linux, which won't have `RSACryptoServiceProvider`.

This is a very much "works on my machine" build and probably shouldn't be merged as-is. I notably have not tested this on net35.

Particularly, further research is needed as to why the `CspParameters` and creating a new `RSACryptoServiceProvider` was needed in the old code. I don't know anything about Windows crypto, so I'm not much help here.

Fixes #117 