### PR TITLE
OWASP Security Tests and Fixes

### DIFF
--- a/src/JWT/Algorithms/RSAlgorithmFactory.cs
+++ b/src/JWT/Algorithms/RSAlgorithmFactory.cs
@@ -20,9 +20,13 @@ namespace JWT.Algorithms
         /// <inheritdoc />
         public override IJwtAlgorithm Create(JwtHashAlgorithm algorithm)
         {
-            return algorithm == JwtHashAlgorithm.RS256 ?
-                       new RS256Algorithm(_certFactory()) :
-                       base.Create(algorithm);
+            switch (algorithm)
+            {
+                case JwtHashAlgorithm.RS256:
+                    return new RS256Algorithm(_certFactory());
+                default:
+                    throw new NotSupportedException($"For algorithm {Enum.GetName(typeof(JwtHashAlgorithm), algorithm)} please use the appropriate factory by implementing {nameof(IAlgorithmFactory)}");
+            }
         }
     }
 }

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using JWT.Algorithms;
+using System;
 using System.Collections.Generic;
 using System.Text;
-using JWT.Algorithms;
 
 namespace JWT
 {
@@ -25,12 +25,7 @@ namespace JWT
         /// <param name="urlEncoder">The Base64 URL Encoder.</param>
         public JwtDecoder(IJsonSerializer jsonSerializer, IJwtValidator jwtValidator, IBase64UrlEncoder urlEncoder)
             : this(jsonSerializer, jwtValidator, urlEncoder, _defaultAlgorithmFactory)
-        {
-            _jsonSerializer = jsonSerializer;
-            _jwtValidator = jwtValidator;
-            _urlEncoder = urlEncoder;
-            _algFactory = _defaultAlgorithmFactory;
-        }
+        { }
 
         /// <summary>
         /// Creates an instance of <see cref="JwtDecoder" />.

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -1,7 +1,7 @@
-﻿using JWT.Algorithms;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using JWT.Algorithms;
 
 namespace JWT
 {
@@ -25,7 +25,8 @@ namespace JWT
         /// <param name="urlEncoder">The Base64 URL Encoder.</param>
         public JwtDecoder(IJsonSerializer jsonSerializer, IJwtValidator jwtValidator, IBase64UrlEncoder urlEncoder)
             : this(jsonSerializer, jwtValidator, urlEncoder, _defaultAlgorithmFactory)
-        { }
+        {
+        }
 
         /// <summary>
         /// Creates an instance of <see cref="JwtDecoder" />.

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -29,6 +29,7 @@ namespace JWT
             _jsonSerializer = jsonSerializer;
             _jwtValidator = jwtValidator;
             _urlEncoder = urlEncoder;
+            _algFactory = _defaultAlgorithmFactory;
         }
 
         /// <summary>

--- a/tests/JWT.Tests.Common/TestCategory.cs
+++ b/tests/JWT.Tests.Common/TestCategory.cs
@@ -1,0 +1,9 @@
+﻿namespace JWT.Tests.Common
+{
+    public static class TestCategory
+    {
+        public const string Category = nameof(Category);
+
+        public const string Security = nameof(Security);
+    }
+}

--- a/tests/JWT.Tests.Common/TestData.cs
+++ b/tests/JWT.Tests.Common/TestData.cs
@@ -10,10 +10,47 @@ namespace JWT.Tests.Common
         public const string MalformedToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9eyJGaXJzdE5hbWUiOiJCb2IiLCJBZ2UiOjM3fQ.cr0xw8c_HKzhFBMQrseSPGoJ0NPlRp_3BKzP96jwBdY";
         public const string ExtraHeadersToken = "eyJmb28iOiJiYXIiLCJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJGaXJzdE5hbWUiOiJCb2IiLCJBZ2UiOjM3fQ.slrbXF9VSrlX7LKsV-Umb_zEzWLxQjCfUOjNTbvyr1g";
 
+        // Security Constants
+        public const string AlgorithmNoneToken = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJGaXJzdE5hbWUiOiJCb2IiLCJBZ2UiOjM3fQ.ANY";
+        
+
         public static readonly IDictionary<string, object> DictionaryPayload = new Dictionary<string, object>
         {
             { "FirstName", "Bob" },
             { "Age", 37 }
         };
+
+        public const string ServerRSAPublicKey = "-----BEGIN CERTIFICATE-----"
+            + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
+            + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
+            + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"
+            + "A1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwgZ8wDQYJ"
+            + "KoZIhvcNAQEBBQADgY0AMIGJAoGBALsspKjcF/mB0nheaT+9KizOeBM6Qpi69LzO"
+            + "LBw8rxohSFJw/BFB/ch+8jXbtq23IwtavJTwSeY6a7pbZgrwCwUK/27gy04m/tum"
+            + "5FJBfCVGTTI4vqUYeTKimQzxj2pupQ+wx//1tKrXMIDGdllmQ/tffQHXxYGBR5Ol"
+            + "543YRN+dAgMBAAGjUDBOMB0GA1UdDgQWBBQMfi0akrZdtPpiYSbE4h2/9vlaozAf"
+            + "BgNVHSMEGDAWgBQMfi0akrZdtPpiYSbE4h2/9vlaozAMBgNVHRMEBTADAQH/MA0G"
+            + "CSqGSIb3DQEBDQUAA4GBAF9pg6H7C7O5/oHeRtKSOPb9WnrHZ/mxAl30wCh2pCtJ"
+            + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
+            + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
+            + "-----END CERTIFICATE-----";
+
+        public const string ServerRSAPrivateKey = "-----BEGIN PRIVATE KEY-----"
+            + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALsspKjcF/mB0nhe"
+            + "aT+9KizOeBM6Qpi69LzOLBw8rxohSFJw/BFB/ch+8jXbtq23IwtavJTwSeY6a7pb"
+            + "ZgrwCwUK/27gy04m/tum5FJBfCVGTTI4vqUYeTKimQzxj2pupQ+wx//1tKrXMIDG"
+            + "dllmQ/tffQHXxYGBR5Ol543YRN+dAgMBAAECgYEAqLIs2dA8f3Fle31ECOF6MJYK"
+            + "HPJGcZcW21BK60w6WSekIkGYvgknLVxU+vvCosDLggFOtEH5qNoAnB6iUrtUgbVg"
+            + "9JlZspfAgMY6uzNBrjrRtMEKWZY7MaURf8S1dkZoR6QdjMnK1/Mjno6J6bl5LBkr"
+            + "wQxVeH3dllkxREOslLUCQQDfygcI7/EYjrktLQUxRI0fV0YDkntNvjDKmwh/pzQs"
+            + "1sW0pj8B7d2pwdOKy+P5p7ubXlXtom2iZZXNWQq/mranAkEA1h13/ZaDSh85YLcH"
+            + "y+MJ/ij5treXdEM5E2uXgMoMBJJhClaMHloFoPIS4Q5Rk1gkI6kWZvA7Ldp2X28x"
+            + "Mz8EGwJAKJSN6gT4hyd6VMLRKjnwDTraK1OooFRYrKSoSd2cDHV1rGhpDISBqYLI"
+            + "RWbrlB3iWy4kDs9hag1ZuL7owA3iCQJAQqEE9+rgjC5PQqNyT6YlM+w4WP2kqc9J"
+            + "cZunl7JILxwGCpuIGuHUopLyAQrdo8Zn6JjzmbDkGY7EC0qkute/RQJAEKofKVOq"
+            + "YouEKIpRSnxeRi45LX0ouRgTmwT/8xr6VxVKe1eToMJ85f/7FXewWR+W1dIN+NXi"
+            + "MzhzkzbNqAeDkg=="
+            + "-----END PRIVATE KEY-----";
+
     }
 }

--- a/tests/JWT.Tests.Core/JwtSecurityTest.cs
+++ b/tests/JWT.Tests.Core/JwtSecurityTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using FluentAssertions;
+using JWT.Algorithms;
+using JWT.Serializers;
+using Xunit;
+using JWT.Tests.Common;
+
+namespace JWT.Tests.Core
+{
+    public class JwtSecurityTest
+    {
+        [Fact]
+        public void Algorithm_None_Should_Throw_Exception()
+        {
+            var serializer = new JsonNetSerializer();
+            var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, validator, urlEncoder);
+
+            Action action = () => decoder.Decode(TestData.AlgorithmNoneToken, "ABC", verify: true);
+
+            action.ShouldThrow<ArgumentException>();
+        }
+
+        [Fact]
+        public void HMAC_Decoding_When_Expecting_RSA_Should_Fail()
+        {
+            var serializer = new JsonNetSerializer();
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var HMACencoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
+
+            var HMACEncodedToken = HMACencoder.Encode(TestData.Customer, TestData.ServerRSAPublicKey);
+
+            // RSA Decoder
+            var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
+            var RSAFactory = new RSAlgorithmFactory(GetRSAPublicKeyAsCertificate);
+            var decoder = new JwtDecoder(serializer, validator, urlEncoder, RSAFactory);
+
+            //var actualPayload = decoder.Decode(HMACEncodedToken, TestData.ServerRSAPublicKey, verify: true);
+
+            Action action = () => decoder.Decode(HMACEncodedToken, TestData.ServerRSAPublicKey, verify: true);
+
+            action.ShouldThrow<SignatureVerificationException>("because HMAC Tokens can be forged in RSA Decoder");
+        }
+    
+        private System.Security.Cryptography.X509Certificates.X509Certificate2 GetRSAPublicKeyAsCertificate()
+        {
+            return new System.Security.Cryptography.X509Certificates.X509Certificate2(TestData.ServerRSAPublicKey);
+        }
+
+    }
+}

--- a/tests/JWT.Tests.Core/JwtSecurityTest.cs
+++ b/tests/JWT.Tests.Core/JwtSecurityTest.cs
@@ -10,6 +10,7 @@ namespace JWT.Tests.Core
     public class JwtSecurityTest
     {
         [Fact]
+        [Trait("Category", "Security")]
         public void Algorithm_None_Should_Throw_Exception()
         {
             var serializer = new JsonNetSerializer();
@@ -23,6 +24,7 @@ namespace JWT.Tests.Core
         }
 
         [Fact]
+        [Trait("Category", "Security")]
         public void HMAC_Decoding_When_Expecting_RSA_Should_Fail()
         {
             var serializer = new JsonNetSerializer();
@@ -40,7 +42,7 @@ namespace JWT.Tests.Core
 
             Action action = () => decoder.Decode(HMACEncodedToken, TestData.ServerRSAPublicKey, verify: true);
 
-            action.ShouldThrow<SignatureVerificationException>("because HMAC Tokens can be forged in RSA Decoder");
+            action.ShouldThrow<NotSupportedException>("because HMAC Tokens can be forged in RSA Decoder");
         }
     
         private System.Security.Cryptography.X509Certificates.X509Certificate2 GetRSAPublicKeyAsCertificate()

--- a/tests/JWT.Tests.Core/JwtSecurityTest.cs
+++ b/tests/JWT.Tests.Core/JwtSecurityTest.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Serializers;
-using Xunit;
 using JWT.Tests.Common;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
 
 namespace JWT.Tests.Core
 {
     public class JwtSecurityTest
     {
         [Fact]
-        [Trait("Category", "Security")]
+        [Trait(TestCategory.Category, TestCategory.Security)]
         public void Algorithm_None_Should_Throw_Exception()
         {
             var serializer = new JsonNetSerializer();
@@ -24,7 +25,7 @@ namespace JWT.Tests.Core
         }
 
         [Fact]
-        [Trait("Category", "Security")]
+        [Trait(TestCategory.Category, TestCategory.Security)]
         public void HMAC_Decoding_When_Expecting_RSA_Should_Fail()
         {
             var serializer = new JsonNetSerializer();
@@ -37,18 +38,15 @@ namespace JWT.Tests.Core
             var validator = new JwtValidator(serializer, new UtcDateTimeProvider());
             var RSAFactory = new RSAlgorithmFactory(GetRSAPublicKeyAsCertificate);
             var decoder = new JwtDecoder(serializer, validator, urlEncoder, RSAFactory);
-
-            //var actualPayload = decoder.Decode(HMACEncodedToken, TestData.ServerRSAPublicKey, verify: true);
-
+            
             Action action = () => decoder.Decode(HMACEncodedToken, TestData.ServerRSAPublicKey, verify: true);
 
             action.ShouldThrow<NotSupportedException>("because HMAC Tokens can be forged in RSA Decoder");
         }
     
-        private System.Security.Cryptography.X509Certificates.X509Certificate2 GetRSAPublicKeyAsCertificate()
+        private X509Certificate2 GetRSAPublicKeyAsCertificate()
         {
-            return new System.Security.Cryptography.X509Certificates.X509Certificate2(TestData.ServerRSAPublicKey);
+            return new X509Certificate2(TestData.ServerRSAPublicKey);
         }
-
     }
 }


### PR DESCRIPTION
Added security tests based on [OWASP JWT recommendations](https://www.owasp.org/index.php/JSON_Web_Token_(JWT)_Cheat_Sheet_for_Java). 

Found and fixed a vulnerability allowing an attacker to create a HMAC Token for an RSA Decoder.

The fix is in two places.
- JwtDecoder - set _algFactory to default when algorithm factory is not passed in.
- RSAFactory - can only use RSA algorithms.

Resources on the Vulnerabilities:
[OWASP JWT Recommendations](https://www.owasp.org/index.php/JSON_Web_Token_(JWT)_Cheat_Sheet_for_Java)
[JWT Critical Vulnerabilities](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/)
[JWT Token Editor](https://jwt.io/)