### PR TITLE
Pin cake version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,8 +275,8 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
-# tools/**
-# !tools/packages.config
+tools/**
+!tools/packages.config
 
 # Telerik's JustMock configuration file
 *.jmconfig

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.21.1" />
+</packages>


### PR DESCRIPTION
Pinning the version of cake used, to avoid any changes that might occur if cake is updated. (see [here](http://cakebuild.net/docs/tutorials/pinning-cake-version))