### PR TITLE
Master based base64url decode padding fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ tools/**
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Mac (Visual Studio for Mac)
+**/*.DS_Store

--- a/src/JWT/JwtBase64UrlEncoder.cs
+++ b/src/JWT/JwtBase64UrlEncoder.cs
@@ -38,6 +38,9 @@ namespace JWT
             {
                 case 0:
                     break; // No pad chars in this case
+                case 1:
+                    output += "===";
+                    break; // Three pad chars
                 case 2:
                     output += "==";
                     break; // Two pad chars


### PR DESCRIPTION
small fix for error in Base64Url Decode with padding (missing 1 for the result of modulo)

Compiled JWT project in VS4Mac and on Windows in VS2017 and with Cake. Green

Could not run Cake on Mac and XUnit tests in VS4Mac. Red