### PR TITLE
Support multiple keys for decoding

### DIFF
--- a/src/JWT/Builder/ClaimName.cs
+++ b/src/JWT/Builder/ClaimName.cs
@@ -5,9 +5,6 @@ namespace JWT.Builder
     /// <summary>
     /// All public claims of a JWT specified by IANA, see https://www.iana.org/assignments/jwt/jwt.xhtml
     /// </summary>
-    /// <remarks>
-    /// Latest update: 31.10.2017
-    /// </remarks>
     public enum ClaimName
     {
         [Description("iss")]
@@ -115,7 +112,7 @@ namespace JWT.Builder
         [Description("cnf")]
         Confirmation,
 
-        [Description("sip_from_tag")]   
+        [Description("sip_from_tag")]
         SipFromTag,
 
         [Description("sip_date")]

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -53,7 +53,7 @@ namespace JWT.Builder
         /// <param name="name">Claim name</param>
         /// <param name="value">Claim value</param>
         /// <returns>Current builder instance</returns>
-        public JwtBuilder AddClaim(string name, string value) => AddClaim(name, (object) value);
+        public JwtBuilder AddClaim(string name, string value) => AddClaim(name, (object)value);
 
         /// <summary>
         /// Adds well-known claim to the JWT.
@@ -157,7 +157,7 @@ namespace JWT.Builder
         /// <returns>Current builder instance</returns>
         public JwtBuilder WithSecret(string secret)
         {
-            _secrets = new[] {secret};
+            _secrets = new[] { secret };
             return this;
         }
 
@@ -240,14 +240,11 @@ namespace JWT.Builder
         private void TryCreateEncoder()
         {
             if (_algorithm == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithAlgorithm)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithAlgorithm)}.");
             if (_serializer == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithSerializer)}");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithSerializer)}");
             if (_urlEncoder == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithUrlEncoder)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithUrlEncoder)}.");
 
             _encoder = new JwtEncoder(_algorithm, _serializer, _urlEncoder);
         }
@@ -257,14 +254,11 @@ namespace JWT.Builder
             TryCreateValidator();
 
             if (_serializer == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithSerializer)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithSerializer)}.");
             if (_validator == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithValidator)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithValidator)}.");
             if (_urlEncoder == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithUrlEncoder)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithUrlEncoder)}.");
 
             EnsureCanDecode();
 
@@ -277,11 +271,9 @@ namespace JWT.Builder
                 return;
 
             if (_serializer == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtValidator)}. Call {nameof(WithSerializer)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtValidator)}. Call {nameof(WithSerializer)}.");
             if (_dateTimeProvider == null)
-                throw new InvalidOperationException(
-                    $"Can't instantiate {nameof(JwtValidator)}. Call {nameof(WithDateTimeProvider)}.");
+                throw new InvalidOperationException($"Can't instantiate {nameof(JwtValidator)}. Call {nameof(WithDateTimeProvider)}.");
 
             _validator = new JwtValidator(_serializer, _dateTimeProvider);
         }
@@ -343,10 +335,7 @@ namespace JWT.Builder
         /// </summary>
         private bool HasSecrets()
         {
-            if (_secrets != null && _secrets.Length > 0)
-                return true;
-
-            return false;
+            return _secrets != null && _secrets.Length > 0;
         }
 
         /// <summary>
@@ -355,9 +344,7 @@ namespace JWT.Builder
         /// <returns></returns>
         private bool HasOnlyOneSecret()
         {
-            if (_secrets != null && _secrets.Length == 1)
-                return true;
-            return false;
+            return _secrets != null && _secrets.Length == 1;
         }
     }
 }

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -20,7 +20,6 @@ namespace JWT.Builder
         private IDateTimeProvider _dateTimeProvider = new UtcDateTimeProvider();
 
         private IJwtAlgorithm _algorithm;
-//        private string _secret;
         private string[] _secrets;
         private bool _verify;
 
@@ -289,17 +288,17 @@ namespace JWT.Builder
 
         private void EnsureCanBuild()
         {
-            if(!HasOnlyOneSecret())
-                throw new InvalidOperationException(
-                    "You can't provide more than one secret to use for encoding." +
-                    $" You should use {nameof(WithSecret)} instead of {nameof(WithSecrets)}.");
-                
             if (!CanBuild())
                 throw new InvalidOperationException(
                     "Can't build a token. Check if you have call all of the followng methods:\r\n" +
                     $"-{nameof(WithAlgorithm)}\r\n" +
                     $"-{nameof(WithSerializer)}\r\n" +
                     $"-{nameof(WithUrlEncoder)}.");
+            
+            if(!HasOnlyOneSecret())
+                throw new InvalidOperationException(
+                    "You can't provide more than one secret to use for encoding." +
+                    $" You should use {nameof(WithSecret)} instead of {nameof(WithSecrets)}.");
         }
 
         private void EnsureCanDecode()
@@ -321,8 +320,7 @@ namespace JWT.Builder
                    _serializer != null &&
                    _urlEncoder != null &&
                    _jwt.Payload != null &&
-                   _algorithm.IsAsymmetric ||
-                   HasOnlyOneSecret();
+                   _algorithm.IsAsymmetric;
         }
 
         /// <summary>
@@ -345,15 +343,16 @@ namespace JWT.Builder
         /// </summary>
         private bool HasSecrets()
         {
-//            if (!string.IsNullOrEmpty(_secret))
-//                return true;
-
             if (_secrets != null && _secrets.Length > 0)
                 return true;
 
             return false;
         }
 
+        /// <summary>
+        /// Checks if there is only one secret was supplied for token encoding
+        /// </summary>
+        /// <returns></returns>
         private bool HasOnlyOneSecret()
         {
             if (_secrets != null && _secrets.Length == 1)

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -281,26 +281,23 @@ namespace JWT.Builder
         private void EnsureCanBuild()
         {
             if (!CanBuild())
-                throw new InvalidOperationException(
-                    "Can't build a token. Check if you have call all of the followng methods:\r\n" +
-                    $"-{nameof(WithAlgorithm)}\r\n" +
-                    $"-{nameof(WithSerializer)}\r\n" +
-                    $"-{nameof(WithUrlEncoder)}.");
-            
-            if(!HasOnlyOneSecret())
-                throw new InvalidOperationException(
-                    "You can't provide more than one secret to use for encoding." +
-                    $" You should use {nameof(WithSecret)} instead of {nameof(WithSecrets)}.");
+                throw new InvalidOperationException("Can't build a token. Check if you have call all of the followng methods:\r\n" +
+                                                    $"-{nameof(WithAlgorithm)}\r\n" +
+                                                    $"-{nameof(WithSerializer)}\r\n" +
+                                                    $"-{nameof(WithUrlEncoder)}.");
+
+            if (!HasOnlyOneSecret())
+                throw new InvalidOperationException("You can't provide more than one secret to use for encoding." +
+                                                    $" You should use {nameof(WithSecret)} instead of {nameof(WithSecrets)}.");
         }
 
         private void EnsureCanDecode()
         {
             if (!CanDecode())
-                throw new InvalidOperationException(
-                    "Can't decode a token. Check if you have call all of the followng methods:\r\n" +
-                    $"-{nameof(WithSerializer)}\r\n" +
-                    $"-{nameof(WithValidator)}\r\n" +
-                    $"-{nameof(WithUrlEncoder)}.");
+                throw new InvalidOperationException("Can't decode a token. Check if you have call all of the followng methods:\r\n" +
+                                                    $"-{nameof(WithSerializer)}\r\n" +
+                                                    $"-{nameof(WithValidator)}\r\n" +
+                                                    $"-{nameof(WithUrlEncoder)}.");
         }
 
         /// <summary>

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -320,7 +320,7 @@ namespace JWT.Builder
                    _serializer != null &&
                    _urlEncoder != null &&
                    _jwt.Payload != null &&
-                   _algorithm.IsAsymmetric;
+                   _algorithm.IsAsymmetric || HasOnlyOneSecret();
         }
 
         /// <summary>

--- a/src/JWT/IJwtDecoder.cs
+++ b/src/JWT/IJwtDecoder.cs
@@ -50,7 +50,7 @@ namespace JWT
         /// <param name="keys">The keys bytes provided which one of them was used to sign the JWT.</param>
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>A string containing the JSON payload.</returns>
-        string Decode(string token, List<byte[]> keys, bool verify);
+        string Decode(string token, IReadOnlyCollection<byte[]> keys, bool verify);
 
         #endregion
 

--- a/src/JWT/IJwtDecoder.cs
+++ b/src/JWT/IJwtDecoder.cs
@@ -104,7 +104,7 @@ namespace JWT
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        IDictionary<string, object> DecodeToObject(string token, List<byte[]> keys, bool verify);
+        IDictionary<string, object> DecodeToObject(string token, IReadOnlyCollection<byte[]> keys, bool verify);
 
         #endregion
 
@@ -164,7 +164,7 @@ namespace JWT
         /// <returns>An object representing the payload.</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
-        T DecodeToObject<T>(string token, List<byte[]> keys, bool verify);
+        T DecodeToObject<T>(string token, IReadOnlyCollection<byte[]> keys, bool verify);
 
         #endregion
     }

--- a/src/JWT/IJwtDecoder.cs
+++ b/src/JWT/IJwtDecoder.cs
@@ -24,6 +24,15 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>A string containing the JSON payload.</returns>
         string Decode(string token, string key, bool verify);
+        
+        /// <summary>
+        /// Given a JWT, decodes it and return the JSON payload.
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The keys provided which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>A string containing the JSON payload.</returns>
+        string Decode(string token, string[] keys, bool verify);
 
         /// <summary>
         /// Given a JWT, decodes it and return the JSON payload.
@@ -33,6 +42,15 @@ namespace JWT
         /// <param name="verify">Whether to verify the signature (default is true).</param>
         /// <returns>A string containing the JSON payload.</returns>
         string Decode(string token, byte[] key, bool verify);
+
+        /// <summary>
+        /// Given a JWT, decodes it and return the JSON payload.
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The keys bytes provided which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>A string containing the JSON payload.</returns>
+        string Decode(string token, List<byte[]> keys, bool verify);
 
         #endregion
 
@@ -54,6 +72,17 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
         IDictionary<string, object> DecodeToObject(string token, string key, bool verify);
+        
+        /// <summary>
+        /// Given a JWT, decodes it and return the payload as an object.
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The key which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        IDictionary<string, object> DecodeToObject(string token, string[] keys, bool verify);
 
         /// <summary>
         /// Given a JWT, decodes it and return the payload as an object.
@@ -65,6 +94,17 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
         IDictionary<string, object> DecodeToObject(string token, byte[] key, bool verify);
+        
+        /// <summary>
+        /// Given a JWT, decodes it and return the payload as an object.
+        /// </summary>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The key which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        IDictionary<string, object> DecodeToObject(string token, List<byte[]> keys, bool verify);
 
         #endregion
 
@@ -89,6 +129,18 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
         T DecodeToObject<T>(string token, string key, bool verify);
+        
+        /// <summary>
+        /// Given a JWT, decodes it and return the payload as an object.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The keys provided which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        T DecodeToObject<T>(string token, string[] keys, bool verify);
 
         /// <summary>
         /// Given a JWT, decodes it and return the payload as an object.
@@ -101,6 +153,18 @@ namespace JWT
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
         T DecodeToObject<T>(string token, byte[] key, bool verify);
+
+        /// <summary>
+        /// Given a JWT, decodes it and return the payload as an object.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to return</typeparam>
+        /// <param name="token">The JWT.</param>
+        /// <param name="keys">The keys which one of them was used to sign the JWT.</param>
+        /// <param name="verify">Whether to verify the signature (default is true).</param>
+        /// <returns>An object representing the payload.</returns>
+        /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm.</exception>
+        /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim.</exception>
+        T DecodeToObject<T>(string token, List<byte[]> keys, bool verify);
 
         #endregion
     }

--- a/src/JWT/IJwtValidator.cs
+++ b/src/JWT/IJwtValidator.cs
@@ -1,4 +1,6 @@
-﻿namespace JWT
+﻿using System.Collections.Generic;
+
+namespace JWT
 {
     /// <summary>
     /// Represents a JWT validator.
@@ -14,5 +16,15 @@
         /// <exception cref="SignatureVerificationException">The signature is invalid.</exception>
         /// <exception cref="TokenExpiredException">The token has expired.</exception>
         void Validate(string payloadJson, string decodedCrypto, string decodedSignature);
+        
+        /// <summary>
+        /// Given the JWT, verifies its signature correctness.
+        /// </summary>
+        /// <param name="payloadJson">>An arbitrary payload (already serialized to JSON).</param>
+        /// <param name="decodedCrypto">Decoded body</param>
+        /// <param name="decodedSignatures">Decoded signatures</param>
+        /// <exception cref="SignatureVerificationException">The signature is invalid.</exception>
+        /// <exception cref="TokenExpiredException">The token has expired.</exception>
+        void Validate(string payloadJson, string decodedCrypto, List<string> decodedSignatures);
     }
 }

--- a/src/JWT/IJwtValidator.cs
+++ b/src/JWT/IJwtValidator.cs
@@ -25,6 +25,6 @@ namespace JWT
         /// <param name="decodedSignatures">Decoded signatures</param>
         /// <exception cref="SignatureVerificationException">The signature is invalid.</exception>
         /// <exception cref="TokenExpiredException">The token has expired.</exception>
-        void Validate(string payloadJson, string decodedCrypto, List<string> decodedSignatures);
+        void Validate(string payloadJson, string decodedCrypto, string[] decodedSignatures);
     }
 }

--- a/src/JWT/IJwtValidator.cs
+++ b/src/JWT/IJwtValidator.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace JWT
+﻿namespace JWT
 {
     /// <summary>
     /// Represents a JWT validator.

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>4.0.0-beta3</Version>
+    <Version>4.0.0-beta4</Version>
     <PackageTags>jwt json</PackageTags>
     <FileVersion>4.0.0.0</FileVersion>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>5.0.0-beta1</Version>
+    <Version>4.0.0</Version>
     <PackageTags>jwt json</PackageTags>
     <FileVersion>5.0.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,10 +18,10 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>4.0.0-beta4</Version>
+    <Version>5.0.0-beta1</Version>
     <PackageTags>jwt json</PackageTags>
-    <FileVersion>4.0.0.0</FileVersion>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>John Sheehan, Michael Lehenbauer, Alexander Batishchev</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>4.0.0</Version>
+    <Version>5.0.0-beta1</Version>
     <PackageTags>jwt json</PackageTags>
     <FileVersion>5.0.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -278,12 +278,12 @@ namespace JWT
 
         private static List<byte[]> GetBytes(IEnumerable<string> input)
         {
-            return input.Select(GetBytes).ToList();
+            return input.Select(key => GetBytes(key)).ToList();
         }
         
         private static string[] GetStrings(IEnumerable<byte[]> input)
         {
-            return input.Select(GetString).ToArray();
+            return input.Select(key => GetString(key)).ToArray();
         }
         
         private static bool DoesKeysHaveValues(IReadOnlyCollection<byte[]> keys)

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -75,7 +75,7 @@ namespace JWT
         /// <exception cref="FormatException" />
         public string Decode(string token, byte[] key, bool verify)
         {
-            if ( String.IsNullOrWhiteSpace(token))
+            if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
@@ -89,7 +89,7 @@ namespace JWT
 
             return Decode(token);
         }
-        
+
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="ArgumentNullException" />
@@ -99,7 +99,7 @@ namespace JWT
         {
             if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
-            if (keys==null || keys.Count ==0)
+            if (keys == null || keys.Count == 0)
                 throw new ArgumentNullException(nameof(keys));
             if (!DoesKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
@@ -125,7 +125,7 @@ namespace JWT
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public IDictionary<string, object> DecodeToObject(string token, string key, bool verify) => DecodeToObject(token, GetBytes(key), verify);
-        
+
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="ArgumentNullException" />
@@ -139,7 +139,7 @@ namespace JWT
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public IDictionary<string, object> DecodeToObject(string token, byte[] key, bool verify) => DecodeToObject<Dictionary<string, object>>(token, key, verify);
-        
+
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="ArgumentNullException" />
@@ -177,7 +177,7 @@ namespace JWT
             var payload = Decode(token, key, verify);
             return _jsonSerializer.Deserialize<T>(payload);
         }
-        
+
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="ArgumentNullException" />
@@ -190,7 +190,7 @@ namespace JWT
         }
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate" />.
+        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string)" />.
         /// </summary>
         /// <param name="parts">The array representation of a JWT.</param>
         /// <param name="key">The key that was used to sign the JWT.</param>
@@ -200,7 +200,7 @@ namespace JWT
         public void Validate(string[] parts, byte[] key) => Validate(new JwtParts(parts), key);
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate" />.
+        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string)" />.
         /// </summary>
         /// <param name="jwt">The JWT parts.</param>
         /// <param name="key">The key that was used to sign the JWT.</param>
@@ -235,9 +235,9 @@ namespace JWT
 
             _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
         }
-        
+
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate" />.
+        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string[])" />.
         /// </summary>
         /// <param name="jwt">The JWT parts.</param>
         /// <param name="keys">The keys provided which one of them was used to sign the JWT.</param>
@@ -267,8 +267,7 @@ namespace JWT
             var algName = (string)headerData["alg"];
             var alg = _algFactory.Create(algName);
 
-            string[] decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign)).Select(sd => Convert.ToBase64String(sd)).ToArray();
-            
+            var decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign)).Select(sd => Convert.ToBase64String(sd)).ToArray();
             _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
         }
 
@@ -280,16 +279,10 @@ namespace JWT
         {
             return input.Select(key => GetBytes(key)).ToList();
         }
-        
-        private static string[] GetStrings(IEnumerable<byte[]> input)
-        {
-            return input.Select(key => GetString(key)).ToArray();
-        }
-        
+
         private static bool DoesKeysHaveValues(IReadOnlyCollection<byte[]> keys)
         {
             return keys.Any(key => key.Length != 0);
         }
-
     }
 }

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -65,6 +65,13 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
+        public string Decode(string token, string[] keys, bool verify) => Decode(token, GetBytes(keys), verify);
+
+        /// <inheritdoc />
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
         public string Decode(string token, byte[] key, bool verify)
         {
             if (String.IsNullOrWhiteSpace(token))
@@ -77,6 +84,28 @@ namespace JWT
             if (verify)
             {
                 Validate(new JwtParts(token), key);
+            }
+
+            return Decode(token);
+        }
+        
+        /// <inheritdoc />
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public string Decode(string token, List<byte[]> keys, bool verify)
+        {
+            if (String.IsNullOrWhiteSpace(token))
+                throw new ArgumentException(nameof(token));
+            if(keys==null || keys.Count ==0)
+                throw new ArgumentNullException(nameof(keys));
+            if (!DoesKeysHaveValues(keys))
+                throw new ArgumentOutOfRangeException(nameof(keys));
+
+            if (verify)
+            {
+                Validate(new JwtParts(token), keys);
             }
 
             return Decode(token);
@@ -95,6 +124,13 @@ namespace JWT
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public IDictionary<string, object> DecodeToObject(string token, string key, bool verify) => DecodeToObject(token, GetBytes(key), verify);
+        
+        /// <inheritdoc />
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public IDictionary<string, object> DecodeToObject(string token, string[] keys, bool verify) => DecodeToObject(token, GetBytes(keys), verify);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
@@ -102,6 +138,13 @@ namespace JWT
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public IDictionary<string, object> DecodeToObject(string token, byte[] key, bool verify) => DecodeToObject<Dictionary<string, object>>(token, key, verify);
+        
+        /// <inheritdoc />
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public IDictionary<string, object> DecodeToObject(string token, List<byte[]> keys, bool verify) => DecodeToObject<Dictionary<string, object>>(token, keys, verify);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
@@ -121,6 +164,8 @@ namespace JWT
         /// <exception cref="FormatException" />
         public T DecodeToObject<T>(string token, string key, bool verify) => DecodeToObject<T>(token, GetBytes(key), verify);
 
+        public T DecodeToObject<T>(string token, string[] keys, bool verify) => DecodeToObject<T>(token, GetBytes(keys), verify);
+
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="ArgumentNullException" />
@@ -129,6 +174,17 @@ namespace JWT
         public T DecodeToObject<T>(string token, byte[] key, bool verify)
         {
             var payload = Decode(token, key, verify);
+            return _jsonSerializer.Deserialize<T>(payload);
+        }
+        
+        /// <inheritdoc />
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public T DecodeToObject<T>(string token, List<byte[]> keys, bool verify)
+        {
+            var payload = Decode(token, keys, verify);
             return _jsonSerializer.Deserialize<T>(payload);
         }
 
@@ -178,9 +234,84 @@ namespace JWT
 
             _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
         }
+        
+        /// <summary>
+        /// Prepares data before calling <see cref="IJwtValidator.Validate" />.
+        /// </summary>
+        /// <param name="jwt">The JWT parts.</param>
+        /// <param name="keys">The keys provided which one of them was used to sign the JWT.</param>
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public void Validate(JwtParts jwt, List<byte[]> keys)
+        {
+            if (jwt == null)
+                throw new ArgumentNullException(nameof(jwt));
+            if (keys == null || keys.Count == 0)
+                throw new ArgumentNullException(nameof(keys));
+            if(!DoesKeysHaveValues(keys))
+                throw new ArgumentOutOfRangeException(nameof(keys));
+
+            var crypto = _urlEncoder.Decode(jwt.Signature);
+            var decodedCrypto = Convert.ToBase64String(crypto);
+
+            var headerJson = GetString(_urlEncoder.Decode(jwt.Header));
+            var headerData = _jsonSerializer.Deserialize<Dictionary<string, object>>(headerJson);
+
+            var payload = jwt.Payload;
+            var payloadJson = GetString(_urlEncoder.Decode(payload));
+
+            var bytesToSign = GetBytes(String.Concat(jwt.Header, ".", payload));
+
+            var algName = (string)headerData["alg"];
+            var alg = _algFactory.Create(algName);
+
+            List<string> decodedSignatures = new List<string>();
+            foreach (byte[] key in keys)
+            {
+                var signatureData = alg.Sign(key, bytesToSign);
+                decodedSignatures.Add(Convert.ToBase64String(signatureData));
+            }
+
+            _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
+        }
 
         private static byte[] GetBytes(string input) => Encoding.UTF8.GetBytes(input);
 
         private static string GetString(byte[] bytes) => Encoding.UTF8.GetString(bytes);
+
+        private static List<byte[]> GetBytes(string[] input)
+        {
+            List<byte[]> bytes = new List<byte[]>();
+            foreach (string value in input)
+            {
+                bytes.Add(GetBytes(value));
+            }
+
+            return bytes;
+        }
+        
+        private static string[] GetStrings(List<byte[]> input)
+        {
+            string[] strings = new string[input.Count];
+            for(int i=0; i< input.Count; i++)
+            {
+                strings[i] = GetString(input[i]);
+            }
+
+            return strings;
+        }
+        
+        private static bool DoesKeysHaveValues(List<byte[]> keys)
+        {
+            foreach (var key in keys)
+            {
+                if (key.Length != 0)
+                    return true;
+            }
+
+            return false;
+        }
+
     }
 }

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -75,7 +75,7 @@ namespace JWT
         /// <exception cref="FormatException" />
         public string Decode(string token, byte[] key, bool verify)
         {
-            if (String.IsNullOrWhiteSpace(token))
+            if ( String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
@@ -99,7 +99,7 @@ namespace JWT
         {
             if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
-            if(keys==null || keys.Count ==0)
+            if (keys==null || keys.Count ==0)
                 throw new ArgumentNullException(nameof(keys));
             if (!DoesKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
@@ -145,7 +145,7 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public IDictionary<string, object> DecodeToObject(string token, List<byte[]> keys, bool verify) => DecodeToObject<Dictionary<string, object>>(token, keys, verify);
+        public IDictionary<string, object> DecodeToObject(string token, IReadOnlyCollection<byte[]> keys, bool verify) => DecodeToObject<Dictionary<string, object>>(token, keys, verify);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
@@ -183,7 +183,7 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public T DecodeToObject<T>(string token, List<byte[]> keys, bool verify)
+        public T DecodeToObject<T>(string token, IReadOnlyCollection<byte[]> keys, bool verify)
         {
             var payload = Decode(token, keys, verify);
             return _jsonSerializer.Deserialize<T>(payload);
@@ -250,7 +250,7 @@ namespace JWT
                 throw new ArgumentNullException(nameof(jwt));
             if (keys == null || keys.Count == 0)
                 throw new ArgumentNullException(nameof(keys));
-            if(!DoesKeysHaveValues(keys))
+            if (!DoesKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
 
             var crypto = _urlEncoder.Decode(jwt.Signature);
@@ -276,7 +276,7 @@ namespace JWT
 
         private static string GetString(byte[] bytes) => Encoding.UTF8.GetString(bytes);
 
-        private static List<byte[]> GetBytes(IEnumerable<string> input)
+        private static IReadOnlyCollection<byte[]> GetBytes(IEnumerable<string> input)
         {
             return input.Select(key => GetBytes(key)).ToList();
         }

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace JWT
@@ -55,34 +56,20 @@ namespace JWT
             ValidateNbfClaim(payloadData, secondsSinceEpoch);
         }
 
-        private bool AreAllDecodedSignaturesNullOrWhiteSpace(List<string> decodedSignatures)
+        private static bool AreAllDecodedSignaturesNullOrWhiteSpace(string[] decodedSignatures)
         {
-            foreach (string decodedSignature in decodedSignatures)
-            {
-                if (!string.IsNullOrWhiteSpace(decodedSignature))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return decodedSignatures.All(string.IsNullOrWhiteSpace);
         }
 
-        private bool IsAnySignatureValid(string decodedCrypto, List<string> decodedSignatures)
+        private static bool IsAnySignatureValid(string decodedCrypto, string[] decodedSignatures)
         {
-            foreach (string decodedSignature in decodedSignatures)
-            {
-                if (CompareCryptoWithSignature(decodedCrypto, decodedSignature))
-                    return true;
-            }
-
-            return false;
+            return decodedSignatures.Any(decodedSignature => CompareCryptoWithSignature(decodedCrypto, decodedSignature));
         }
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="SignatureVerificationException" />
-        public void Validate(string payloadJson, string decodedCrypto, List<string> decodedSignatures)
+        public void Validate(string payloadJson, string decodedCrypto, string[] decodedSignatures)
         {
             if (String.IsNullOrWhiteSpace(payloadJson))
                 throw new ArgumentException(nameof(payloadJson));
@@ -123,7 +110,7 @@ namespace JWT
             byte result = 0;
             for (var i = 0; i < decodedCrypto.Length; i++)
             {
-                result |= (byte) (decodedCryptoBytes[i] ^ decodedSignatureBytes[i]);
+                result |= (byte)(decodedCryptoBytes[i] ^ decodedSignatureBytes[i]);
             }
 
             return result == 0;

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -58,7 +58,7 @@ namespace JWT
 
         private static bool AreAllDecodedSignaturesNullOrWhiteSpace(string[] decodedSignatures)
         {
-            return decodedSignatures.All(string.IsNullOrWhiteSpace);
+            return decodedSignatures.All(sgn => String.IsNullOrWhiteSpace(sgn));
         }
 
         private static bool IsAnySignatureValid(string decodedCrypto, string[] decodedSignatures)

--- a/tests/JWT.Tests.Common/JwtBuilderDecodeTest.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderDecodeTest.cs
@@ -10,6 +10,7 @@ namespace JWT.Tests.Common
     {
         private const string _sampleToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjbGFpbTEiOjAsImNsYWltMiI6ImNsYWltMi12YWx1ZSJ9.8pwBI_HtXqI3UgQHQ_rDRnSQRxFL1SR8fbQoS-5kM5s";
         private const string _sampleSecret = "GQDstcKsx0NHjPOuXOYg5MbeJ1XT0uFiwDVvVBrk";
+        private readonly string[] _sampleSecrets = {"GQDstcKsx0NHjPOuXOYg5MbeJ1XT0uFiwDVvVBrk", "QWORIJkmQWEDIHbjhOIHAUSDFOYnUGWEYT"};
 
         [Fact]
         public void DecodeToken()
@@ -111,6 +112,17 @@ namespace JWT.Tests.Common
 
             Assert.NotEmpty(payload);
         }
+        
+        [Fact]
+        public void DecodeToken_WithVerifySignature_MultipleSecrets()
+        {
+            var payload = new JwtBuilder()
+                .WithSecrets(_sampleSecrets)
+                .MustVerifySignature()
+                .Decode(_sampleToken);
+
+            Assert.NotEmpty(payload);
+        }
 
         [Fact]
         public void DecodeToken_WithoutVerifySignature()
@@ -132,6 +144,18 @@ namespace JWT.Tests.Common
 
             Assert.True(payload.Count == 2 && payload["claim1"] == 0.ToString());
         }
+        
+        [Fact]
+        public void DecodeToken_ToDictionary_MultipleSecrets()
+        {
+            var payload = new JwtBuilder()
+                .WithSecrets(_sampleSecrets)
+                .MustVerifySignature()
+                .Decode<Dictionary<string, string>>(_sampleToken);
+
+            Assert.True(payload.Count == 2 && payload["claim1"] == 0.ToString());
+        }
+        
 
         [Fact]
         public void DecodeToken_ToDictionary_WithoutSerializer_Should_Throw_Exception()

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
@@ -62,5 +62,13 @@ namespace JWT.Tests.Common
                                          .WithSecret("fjhsdghflghlk")
                                          .Build());
         }
+        
+        [Fact]
+        public void Build_WithMultipleSecrets_Should_Throw_Exception()
+        {
+            Assert.Throws<InvalidOperationException>(() => new JwtBuilder()
+                .WithSecrets(new []{ "fjhsdghflghlk", "wrouhsfjkghure"})
+                .Build());
+        }
     }
 }

--- a/tests/JWT.Tests.Common/JwtSecurityTest.cs
+++ b/tests/JWT.Tests.Common/JwtSecurityTest.cs
@@ -25,6 +25,20 @@ namespace JWT.Tests.Common
 
         [Fact]
         [Trait(TestCategory.Category, TestCategory.Security)]
+        public void Decode_Should_Throw_Exception_When_Non_Algorithm_Was_Used_MultipleKeys()
+        {
+            var serializer = new JsonNetSerializer();
+            var validTor = new JwtValidator(serializer, new UtcDateTimeProvider());
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var decoder = new JwtDecoder(serializer, validTor, urlEncoder);
+
+            Action action = () => decoder.Decode(TestData.AlgorithmNoneToken, new[] {"ABC", "XYZ"}, verify: true);
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Fact]
+        [Trait(TestCategory.Category, TestCategory.Security)]
         public void Decode_Should_Throw_Exception_When_HMA_Algorithm_Is_Used_But_RSA_Was_Expected()
         {
             var serializer = new JsonNetSerializer();
@@ -38,6 +52,25 @@ namespace JWT.Tests.Common
             var decoder = new JwtDecoder(serializer, validTor, urlEncoder, algFactory);
 
             Action action = () => decoder.Decode(encodedToken, TestData.ServerRsaPublicKey, verify: true);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Fact]
+        [Trait(TestCategory.Category, TestCategory.Security)]
+        public void Decode_Should_Throw_Exception_When_HMA_Algorithm_Is_Used_But_RSA_Was_Expected_MultipleKeys()
+        {
+            var serializer = new JsonNetSerializer();
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
+
+            var encodedToken = encoder.Encode(TestData.Customer, TestData.ServerRsaPublicKey);
+
+            var validTor = new JwtValidator(serializer, new UtcDateTimeProvider());
+            var algFactory = new RSAlgorithmFactory(() => new X509Certificate2(TestData.ServerRsaPublicKey));
+            var decoder = new JwtDecoder(serializer, validTor, urlEncoder, algFactory);
+
+            Action action = () => decoder.Decode(encodedToken, TestData.ServerRsaPublicKeys, verify: true);
 
             Assert.Throws<NotSupportedException>(action);
         }

--- a/tests/JWT.Tests.Common/JwtSecurityTest.cs
+++ b/tests/JWT.Tests.Common/JwtSecurityTest.cs
@@ -45,13 +45,13 @@ namespace JWT.Tests.Common
             var urlEncoder = new JwtBase64UrlEncoder();
             var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
 
-            var encodedToken = encoder.Encode(TestData.Customer, TestData.ServerRsaPublicKey);
+            var encodedToken = encoder.Encode(TestData.Customer, TestData.ServerRsaPublicKey1);
 
             var validTor = new JwtValidator(serializer, new UtcDateTimeProvider());
-            var algFactory = new RSAlgorithmFactory(() => new X509Certificate2(TestData.ServerRsaPublicKey));
+            var algFactory = new RSAlgorithmFactory(() => new X509Certificate2(TestData.ServerRsaPublicKey1));
             var decoder = new JwtDecoder(serializer, validTor, urlEncoder, algFactory);
 
-            Action action = () => decoder.Decode(encodedToken, TestData.ServerRsaPublicKey, verify: true);
+            Action action = () => decoder.Decode(encodedToken, TestData.ServerRsaPublicKey1, verify: true);
 
             Assert.Throws<NotSupportedException>(action);
         }
@@ -64,10 +64,10 @@ namespace JWT.Tests.Common
             var urlEncoder = new JwtBase64UrlEncoder();
             var encoder = new JwtEncoder(new HMACSHA256Algorithm(), serializer, urlEncoder);
 
-            var encodedToken = encoder.Encode(TestData.Customer, TestData.ServerRsaPublicKey);
+            var encodedToken = encoder.Encode(TestData.Customer, TestData.ServerRsaPublicKey1);
 
             var validTor = new JwtValidator(serializer, new UtcDateTimeProvider());
-            var algFactory = new RSAlgorithmFactory(() => new X509Certificate2(TestData.ServerRsaPublicKey));
+            var algFactory = new RSAlgorithmFactory(() => new X509Certificate2(TestData.ServerRsaPublicKey1));
             var decoder = new JwtDecoder(serializer, validTor, urlEncoder, algFactory);
 
             Action action = () => decoder.Decode(encodedToken, TestData.ServerRsaPublicKeys, verify: true);

--- a/tests/JWT.Tests.Common/Models/TestData.cs
+++ b/tests/JWT.Tests.Common/Models/TestData.cs
@@ -18,9 +18,9 @@ namespace JWT.Tests.Common.Models
             { "Age", 37 }
         };
 
-        public static readonly string[] ServerRsaPublicKeys = {ServerRsaPublicKey, ServerAnotherRsaPublicKey};
+        public static readonly string[] ServerRsaPublicKeys = {ServerRsaPublicKey1, ServerRsaPublicKey2};
 
-        public const string ServerRsaPublicKey = "-----BEGIN CERTIFICATE-----"
+        public const string ServerRsaPublicKey1 = "-----BEGIN CERTIFICATE-----"
             + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
             + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
             + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"
@@ -35,7 +35,7 @@ namespace JWT.Tests.Common.Models
             + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
             + "-----END CERTIFICATE-----";
         
-        public const string ServerAnotherRsaPublicKey = "-----BEGIN CERTIFICATE-----"
+        public const string ServerRsaPublicKey2 = "-----BEGIN CERTIFICATE-----"
                                                  + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
                                                  + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
                                                  + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"

--- a/tests/JWT.Tests.Common/Models/TestData.cs
+++ b/tests/JWT.Tests.Common/Models/TestData.cs
@@ -18,6 +18,8 @@ namespace JWT.Tests.Common.Models
             { "Age", 37 }
         };
 
+        public static readonly string[] ServerRsaPublicKeys = {ServerRsaPublicKey, ServerAnotherRsaPublicKey};
+
         public const string ServerRsaPublicKey = "-----BEGIN CERTIFICATE-----"
             + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
             + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
@@ -32,6 +34,21 @@ namespace JWT.Tests.Common.Models
             + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
             + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
             + "-----END CERTIFICATE-----";
+        
+        public const string ServerAnotherRsaPublicKey = "-----BEGIN CERTIFICATE-----"
+                                                 + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
+                                                 + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
+                                                 + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"
+                                                 + "A1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwgZ8wDQYJ"
+                                                 + "KoZIhvcNAQEBBQADgY0AMIGJAoGBALsspKjcF/mB0nheaT+9KizOeBM6Qpi69LzO"
+                                                 + "LBw8rxohSFJw/BFB/ch+8jXbtq23IwtavJTwSeY6a7pbZgrwCwUK/27gy04m/tum"
+                                                 + "5FJBfCVGTTI4vqUYeTKimQzxj2pupQ+wx//1tKrXMIDGdllmQ/tffQHXxYGBR5Ol"
+                                                 + "543YRN+dAgMBAAGjUDBOMB0GA1UdDgQWBBQMfi0akrZdtPpiYSbE4h2/9vlaozAf"
+                                                 + "BgNVHSMEGDAWgBQMfi0akrZdtPpiYSbE4h2/9vlaozAMBgNVHRMEBTADAQH/MA0G"
+                                                 + "CSqGSIb3DQEBDQUAA4GBAF9pg6H7C7O5/oHeRtKSOPb9WnrHZ/mxAl30wCh2pCtJ"
+                                                 + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
+                                                 + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
+                                                 + "-----END CERTIFICATE-----";
 
         public const string ServerRsaPrivateKey = "-----BEGIN PRIVATE KEY-----"
             + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALsspKjcF/mB0nhe"

--- a/tests/JWT.Tests.Common/Models/TestData.cs
+++ b/tests/JWT.Tests.Common/Models/TestData.cs
@@ -34,21 +34,21 @@ namespace JWT.Tests.Common.Models
             + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
             + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
             + "-----END CERTIFICATE-----";
-        
+
         public const string ServerRsaPublicKey2 = "-----BEGIN CERTIFICATE-----"
-                                                 + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
-                                                 + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
-                                                 + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"
-                                                 + "A1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwgZ8wDQYJ"
-                                                 + "KoZIhvcNAQEBBQADgY0AMIGJAoGBALsspKjcF/mB0nheaT+9KizOeBM6Qpi69LzO"
-                                                 + "LBw8rxohSFJw/BFB/ch+8jXbtq23IwtavJTwSeY6a7pbZgrwCwUK/27gy04m/tum"
-                                                 + "5FJBfCVGTTI4vqUYeTKimQzxj2pupQ+wx//1tKrXMIDGdllmQ/tffQHXxYGBR5Ol"
-                                                 + "543YRN+dAgMBAAGjUDBOMB0GA1UdDgQWBBQMfi0akrZdtPpiYSbE4h2/9vlaozAf"
-                                                 + "BgNVHSMEGDAWgBQMfi0akrZdtPpiYSbE4h2/9vlaozAMBgNVHRMEBTADAQH/MA0G"
-                                                 + "CSqGSIb3DQEBDQUAA4GBAF9pg6H7C7O5/oHeRtKSOPb9WnrHZ/mxAl30wCh2pCtJ"
-                                                 + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
-                                                 + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
-                                                 + "-----END CERTIFICATE-----";
+            + "MIICPDCCAaWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADA7MQswCQYDVQQGEwJ1czEL"
+            + "MAkGA1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwHhcN"
+            + "MTcwNjI3MTgzNjM3WhcNMjAwMzIzMTgzNjM3WjA7MQswCQYDVQQGEwJ1czELMAkG"
+            + "A1UECAwCVVMxETAPBgNVBAoMCENlcnR0ZXN0MQwwCgYDVQQDDANqd3QwgZ8wDQYJ"
+            + "KoZIhvcNAQEBBQADgY0AMIGJAoGBALsspKjcF/mB0nheaT+9KizOeBM6Qpi69LzO"
+            + "LBw8rxohSFJw/BFB/ch+8jXbtq23IwtavJTwSeY6a7pbZgrwCwUK/27gy04m/tum"
+            + "5FJBfCVGTTI4vqUYeTKimQzxj2pupQ+wx//1tKrXMIDGdllmQ/tffQHXxYGBR5Ol"
+            + "543YRN+dAgMBAAGjUDBOMB0GA1UdDgQWBBQMfi0akrZdtPpiYSbE4h2/9vlaozAf"
+            + "BgNVHSMEGDAWgBQMfi0akrZdtPpiYSbE4h2/9vlaozAMBgNVHRMEBTADAQH/MA0G"
+            + "CSqGSIb3DQEBDQUAA4GBAF9pg6H7C7O5/oHeRtKSOPb9WnrHZ/mxAl30wCh2pCtJ"
+            + "LkgMKKhquYmKqTA+QWpSF/Qeaq17DAf7Wq8VQ2QES9WCQm+PlBlTeZAf3UTLkxIU"
+            + "DchuS8mR7QAgG67QNLl2OKMC4NWzq0d6ZYNzVqHHPe2AKgsRro6SEAv0Sf2QhE3j"
+            + "-----END CERTIFICATE-----";
 
         public const string ServerRsaPrivateKey = "-----BEGIN PRIVATE KEY-----"
             + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALsspKjcF/mB0nhe"


### PR DESCRIPTION
In AWS Cognito, they are the ones who create and sign the token. To verify the signature, they are providing multiple keys, one of them used to sign the token, and you don't know which exactly. We need to support adding multiple keys/secrets when decoding and use them to verify the signature.
I've added the new functions:

- `.WithSecrets(string[] keys)` in `JwtBuilder`
- `DecodeToObject(string token, string[] keys, bool verify)` in `JwtDecoder`