### PR TITLE
Change the RS256Algorithm to take in the RSA Service Provider/RSA

### DIFF
--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -8,14 +8,18 @@ namespace JWT.Algorithms
     /// </summary>
     public sealed class RS256Algorithm : IJwtAlgorithm
     {
-        private readonly X509Certificate2 _cert;
+        private readonly RSACryptoServiceProvider _publicKey;
+        private readonly RSA _privateKey;
 
         /// <summary>
         /// Creates an instance using the provided certificate.
         /// </summary>
-        public RS256Algorithm(X509Certificate2 cert)
+        /// <param name="publicKey">The RSA service provider for verifying the data.</param>
+        /// <param name="privateKey">The RSA key for signing the data.</param>
+        public RS256Algorithm(RSACryptoServiceProvider publicKey, RSA privateKey)
         {
-            _cert = cert;
+            _publicKey = publicKey;
+            _privateKey = privateKey;
         }
 
         /// <inheritdoc />
@@ -27,13 +31,14 @@ namespace JWT.Algorithms
         /// <inheritdoc />
         public byte[] Sign(byte[] key, byte[] bytesToSign) => Sign(bytesToSign);
 
+        /// <summary>
+        /// Signs the provided bytes.
+        /// </summary>
+        /// <param name="bytesToSign">The bytes to sign.</param>
+        /// <returns>The signed bytes.</returns>
         public byte[] Sign(byte[] bytesToSign)
         {
-            if (!_cert.HasPrivateKey)
-                throw new CryptographicException("Certificate doesn't contain private key");
-
-            var privateKey = GetPrivateKey(_cert);
-            return privateKey.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return _privateKey.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 
         /// <summary>
@@ -43,28 +48,10 @@ namespace JWT.Algorithms
         /// <param name="signature">The signature to verify with</param>
         public bool Verify(byte[] bytesToSign, byte[] signature)
         {
-            var publicKey = GetPublicKey(_cert);
-            return publicKey.VerifyData(bytesToSign, "2.16.840.1.101.3.4.2.1", signature);
-        }
-
-        private static RSA GetPrivateKey(X509Certificate2 cert)
-        {
-#if NETSTANDARD1_3
-            return cert.GetRSAPrivateKey();
-#else
-            return (RSA)cert.PrivateKey;
-#endif
-        }
-
-        private static RSACryptoServiceProvider GetPublicKey(X509Certificate2 cert)
-        {
-            AsymmetricAlgorithm alg;
-#if NETSTANDARD1_3
-            alg = cert.GetRSAPublicKey();
-#else
-            alg = cert.PublicKey.Key;
-#endif
-            return (RSACryptoServiceProvider)alg;
+            // 2.16.840.1.101.3.4.2.1 is the object id for the sha256NoSign algorithm.
+            // See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnap/a48b02b2-2a10-4eb0-bed4-1807a6d2f5ad
+            // for further details.
+            return _publicKey.VerifyData(bytesToSign, "2.16.840.1.101.3.4.2.1", signature);
         }
     }
 }

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -27,15 +27,17 @@ namespace JWT.Algorithms
         /// </summary>
         /// <param name="cert">The certificate having both public and private keys.</param>
         public RS256Algorithm(X509Certificate2 cert)
-            : this(GetPublicKey(cert), GetPrivateKeys(cert))
+            : this(GetPublicKey(cert), GetPrivateKey(cert))
         {
         }
 
         /// <inheritdoc />
-        public string Name => JwtHashAlgorithm.RS256.ToString();
+        public string Name =>
+            JwtHashAlgorithm.RS256.ToString();
 
         /// <inheritdoc />
-        public bool IsAsymmetric { get; } = true;
+        public bool IsAsymmetric =>
+            true;
 
         /// <inheritdoc />
         public byte[] Sign(byte[] key, byte[] bytesToSign) =>
@@ -47,7 +49,7 @@ namespace JWT.Algorithms
         /// <param name="bytesToSign">The bytes to sign.</param>
         /// <returns>The signed bytes.</returns>
         public byte[] Sign(byte[] bytesToSign) =>
-            return _privateKey.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            _privateKey.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
         /// <summary>
         /// Verifies provided byte array with provided signature.

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -12,7 +12,7 @@ namespace JWT.Algorithms
         private readonly RSA _privateKey;
 
         /// <summary>
-        /// Creates an instance using the provided certificate.
+        /// Creates an instance using the provided pair of public and private keys.
         /// </summary>
         /// <param name="publicKey">The RSA service provider for verifying the data.</param>
         /// <param name="privateKey">The RSA key for signing the data.</param>
@@ -20,6 +20,15 @@ namespace JWT.Algorithms
         {
             _publicKey = publicKey;
             _privateKey = privateKey;
+        }
+        
+        /// <summary>
+        /// Creates an instance using the provided certificate.
+        /// </summary>
+        /// <param name="cert">The certificate having both public and private keys.</param>
+        public RS256Algorithm(X509Certificate2 cert)
+            : thise(GetPublicKey(cert), GetPrivateKeys(cert))
+        {
         }
 
         /// <inheritdoc />
@@ -50,6 +59,26 @@ namespace JWT.Algorithms
             // 2.16.840.1.101.3.4.2.1 is the object id for the sha256NoSign algorithm.
             // See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnap/a48b02b2-2a10-4eb0-bed4-1807a6d2f5ad for further details.
             return _publicKey.VerifyData(bytesToSign, "2.16.840.1.101.3.4.2.1", signature);
+        }
+        
+        private static RSA GetPrivateKey(X509Certificate2 cert)
+        {
+#if NETSTANDARD1_3
+            return cert.GetRSAPrivateKey();
+#else
+            return (RSA)cert.PrivateKey;
+#endif
+        }
+
+        private static RSACryptoServiceProvider GetPublicKey(X509Certificate2 cert)
+        {
+            AsymmetricAlgorithm alg;
+#if NETSTANDARD1_3
+            alg = cert.GetRSAPublicKey();
+#else
+            alg = cert.PublicKey.Key;
+#endif
+            return (RSACryptoServiceProvider)alg;
         }
     }
 }

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -27,7 +27,7 @@ namespace JWT.Algorithms
         /// </summary>
         /// <param name="cert">The certificate having both public and private keys.</param>
         public RS256Algorithm(X509Certificate2 cert)
-            : thise(GetPublicKey(cert), GetPrivateKeys(cert))
+            : this(GetPublicKey(cert), GetPrivateKeys(cert))
         {
         }
 

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -29,17 +29,16 @@ namespace JWT.Algorithms
         public bool IsAsymmetric { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Sign(byte[] key, byte[] bytesToSign) => Sign(bytesToSign);
+        public byte[] Sign(byte[] key, byte[] bytesToSign) =>
+            Sign(bytesToSign);
 
         /// <summary>
         /// Signs the provided bytes.
         /// </summary>
         /// <param name="bytesToSign">The bytes to sign.</param>
         /// <returns>The signed bytes.</returns>
-        public byte[] Sign(byte[] bytesToSign)
-        {
+        public byte[] Sign(byte[] bytesToSign) =>
             return _privateKey.SignData(bytesToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-        }
 
         /// <summary>
         /// Verifies provided byte array with provided signature.
@@ -49,8 +48,7 @@ namespace JWT.Algorithms
         public bool Verify(byte[] bytesToSign, byte[] signature)
         {
             // 2.16.840.1.101.3.4.2.1 is the object id for the sha256NoSign algorithm.
-            // See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnap/a48b02b2-2a10-4eb0-bed4-1807a6d2f5ad
-            // for further details.
+            // See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-gpnap/a48b02b2-2a10-4eb0-bed4-1807a6d2f5ad for further details.
             return _publicKey.VerifyData(bytesToSign, "2.16.840.1.101.3.4.2.1", signature);
         }
     }

--- a/src/JWT/Algorithms/RSAlgorithmFactory.cs
+++ b/src/JWT/Algorithms/RSAlgorithmFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace JWT.Algorithms
@@ -23,7 +24,12 @@ namespace JWT.Algorithms
             switch (algorithm)
             {
                 case JwtHashAlgorithm.RS256:
-                    return new RS256Algorithm(_certFactory());
+                    var certificate = _certFactory();
+#if NETSTANDARD1_3
+                    return new RS256Algorithm((RSACryptoServiceProvider)certificate.GetRSAPublicKey(), certificate.GetRSAPrivateKey());
+#else
+                    return new RS256Algorithm((RSACryptoServiceProvider)certificate.PublicKey.Key, (RSA)certificate.PrivateKey);
+#endif
                 default:
                     throw new NotSupportedException($"For algorithm {Enum.GetName(typeof(JwtHashAlgorithm), algorithm)} please use the appropriate factory by implementing {nameof(IAlgorithmFactory)}");
             }

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,10 +18,10 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>5.0.1</Version>
+    <Version>5.1.0</Version>
     <PackageTags>jwt json</PackageTags>
-    <FileVersion>5.0.0.0</FileVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.1.0.0</FileVersion>
+    <AssemblyVersion>5.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This fixes #164

This changes the RS256Algorithm class not to directly take in a Certificate but instead get the RSA/RSACryptoServiceProvider combination.

this is helpful in scenarios such as AWS Cognitio where they provide the modulo and exponent  directly.