### PR TITLE
Add additional framework targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Package is avaliable via [NuGet](https://nuget.org/packages/JWT). Or you can dow
 
 ## Supported .NET versions:
 - .NET Framework 4.6.0
+- .NET Framework 4.7.2
 - .NET Standard 1.3
+- .NET Standard 2.0
 
 ## Usage
 ### Creating (encoding) token

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;net472;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net472'">
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
   </PropertyGroup>
 
@@ -39,7 +39,7 @@
    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>5.1.1</Version>
+    <Version>5.2.0</Version>
     <PackageTags>jwt json</PackageTags>
     <FileVersion>5.0.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>


### PR DESCRIPTION
Thanks for this library! This PR makes minor tweaks to the targeted frameworks to follow best practice advice 🙂

As you've included a .NET Framework 1.x target, best practice advice is to also include a .NET Standard 2.0 target ([as described in this doc](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting)). This avoids bringing in loads of extra packages on non-NETFX frameworks that support .NET Standard 2.0 (e.g. .NET Core)

Unfortunately, .NET Standard support is all screwed up around `net461`. As you already have a `net46` target, all that's needed to fully fix it is the `net472` target.

From a practical point of view, this shouldn't have any impact on consumers, other than simplifying the package graph on .NET Core!