### PR TITLE
Add method to add several claims

### DIFF
--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using JWT.Algorithms;
 using JWT.Serializers;
@@ -58,6 +59,20 @@ namespace JWT.Builder
         /// <returns>Current builder instance</returns>
         public JwtBuilder AddClaim(string name, string value) =>
             AddClaim(name, (object)value);
+
+        /// <summary>
+        /// Add several claims to the JWT
+        /// </summary>
+        /// <param name="claims">IDictionary of claims to be added</param>
+        /// <returns>Current builder instance</returns>
+        public JwtBuilder AddClaims(IDictionary<string, object> claims)
+        {
+            foreach (var entry in claims)
+            {
+                AddClaim(entry.Key, entry.Value);
+            }
+            return this;
+        }
 
         /// <summary>
         /// Adds well-known claim to the JWT.

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/jwt-dotnet/jwt</PackageProjectUrl>
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageLicenseUrl>https://creativecommons.org/publicdomain/zero/1.0/</PackageLicenseUrl>
-    <Version>5.2.2</Version>
+    <Version>5.2.3</Version>
     <PackageTags>jwt json</PackageTags>
     <FileVersion>5.0.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="Newtonsoft.Json" Version="9.1.1" />
+   <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+   <PackageReference Include="Newtonsoft.Json" Version="9.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using JWT.Algorithms;
@@ -32,6 +33,25 @@ namespace JWT.Tests.Common
 
             var decodedToken = Encoding.UTF8.GetString(new JwtBase64UrlEncoder().Decode(token.Split('.')[1]));
             Assert.True(decodedToken.Contains("exp") && decodedToken.Contains(testtime));
+        }
+
+        [Fact]
+        public void Build_WithPayloadWithClaims()
+        {
+            var token = new JwtBuilder()
+                .WithAlgorithm(new HMACSHA256Algorithm())
+                .WithSecret("gsdhjfkhdfjklhjklgfsdhgfbsdgfvsdvfghjdjfgb")
+                .AddClaims(new Dictionary<string, object>
+                {
+                    {"key-1", "value-1"},
+                    {"key-2", "value-2"},
+                })
+                .Build();
+            Assert.True(token.Length > 0 && token.Split('.').Length == 3);
+
+            var decodedToken = Encoding.UTF8.GetString(new JwtBase64UrlEncoder().Decode(token.Split('.')[1]));
+            Assert.True(decodedToken.Contains("key-1") && decodedToken.Contains("value-1"));
+            Assert.True(decodedToken.Contains("key-2") && decodedToken.Contains("value-2"));
         }
 
         [Fact]

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTest.cs
@@ -43,8 +43,8 @@ namespace JWT.Tests.Common
                 .WithSecret("gsdhjfkhdfjklhjklgfsdhgfbsdgfvsdvfghjdjfgb")
                 .AddClaims(new Dictionary<string, object>
                 {
-                    {"key-1", "value-1"},
-                    {"key-2", "value-2"},
+                    { "key-1", "value-1" },
+                    { "key-2", "value-2" }
                 })
                 .Build();
             Assert.True(token.Length > 0 && token.Split('.').Length == 3);


### PR DESCRIPTION
# The "why"

While using this library in my company, we would have liked to use the builder to add several claims in a more readable way.

We would have liked to be allowed to do something such as:

```csharp
var token = new JwtBuilder()
      .WithAlgorithm(new HMACSHA256Algorithm())
      .WithSecret(secret)
      .AddClaims({
          "my-claim": "my-value",
          "my-claim-2": "my-value-2"
      })
     .Build();
```

# PR content

I just added a method `AddClaims` allowing the user to pass a IDictionnary of `string: object` in it and add each of its key as a new claim and each of its value as claim value.
