### PR TITLE
Replacing xUnit with MSTest2

### DIFF
--- a/JWT.sln
+++ b/JWT.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		JWT.sln.DotSettings = JWT.sln.DotSettings
+		LICENSE.txt = LICENSE.txt
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,13 @@
 JWT for .NET
 Written by John Sheehan
 (http://john-sheehan.com)
- 
+
 This work is public domain.
-"The person who associated a work with this document has 
+"The person who associated a work with this document has
  dedicated the work to the Commons by waiving all of his
  or her rights to the work worldwide under copyright law
  and all related or neighboring legal rights he or she
  had in the work, to the extent allowable by law."
-  
+
 For more information, please visit:
 http://creativecommons.org/publicdomain/zero/1.0/

--- a/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
+++ b/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>

--- a/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
+++ b/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
@@ -7,7 +7,10 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
+++ b/tests/JWT.Tests.Common/JWT.Tests.Common.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>

--- a/tests/JWT.Tests.Common/JwtBuilderDecodeTests.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderDecodeTests.cs
@@ -3,27 +3,28 @@ using System.Collections.Generic;
 using FluentAssertions;
 using JWT.Builder;
 using JWT.Serializers;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtBuilderDecodeTests
     {
         private const string _sampleToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjbGFpbTEiOjAsImNsYWltMiI6ImNsYWltMi12YWx1ZSJ9.8pwBI_HtXqI3UgQHQ_rDRnSQRxFL1SR8fbQoS-5kM5s";
         private const string _sampleSecret = "GQDstcKsx0NHjPOuXOYg5MbeJ1XT0uFiwDVvVBrk";
         private readonly string[] _sampleSecrets = { "GQDstcKsx0NHjPOuXOYg5MbeJ1XT0uFiwDVvVBrk", "QWORIJkmQWEDIHbjhOIHAUSDFOYnUGWEYT" };
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken()
         {
             var payload = new JwtBuilder()
                 .Decode(_sampleToken);
 
             payload.Should()
-                .NotBeEmpty("because the decoded token contains values and they should have been fetched");
+                   .NotBeEmpty("because the decoded token contains values and they should have been fetched");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutToken_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -35,7 +36,7 @@ namespace JWT.Tests.Common
                             .Throw<ArgumentException>("because null is not a valid value for a token");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutSerializer_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -50,7 +51,7 @@ namespace JWT.Tests.Common
                                        .Throw<InvalidOperationException>("because a token can't be decoded without a valid serializer");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithSerializer()
         {
             var builder = new JwtBuilder();
@@ -65,7 +66,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because the token should be correctly decoded and its data extracted");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutUrlEncoder_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -80,7 +81,7 @@ namespace JWT.Tests.Common
                                     .Throw<InvalidOperationException>("because a token can't be decoded without a valid UrlEncoder");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithUrlEncoder()
         {
             var builder = new JwtBuilder();
@@ -95,7 +96,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because the token should have been correctly decoded with the valid base 64 encoder");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutTimeProvider_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -111,7 +112,7 @@ namespace JWT.Tests.Common
                                                .Throw<InvalidOperationException>("because a token can't be decoded without a valid DateTimeProvider");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithDateTimeProvider()
         {
             var builder = new JwtBuilder();
@@ -127,7 +128,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because the decoding process must be successful with a valid DateTimeProvider");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutValidator()
         {
             var builder = new JwtBuilder();
@@ -142,7 +143,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because a JWT should not necessary have a validator to be decoded");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithExplicitValidator()
         {
             var builder = new JwtBuilder();
@@ -159,7 +160,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because a JWT should be correctly decoded, even with a validator");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithVerifySignature()
         {
             var builder = new JwtBuilder();
@@ -175,7 +176,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because the signature must have been verified successfully and the JWT correctly decoded");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithVerifySignature_MultipleSecrets()
         {
             var builder = new JwtBuilder();
@@ -191,7 +192,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because one of the provided signatures must have been verified successfully and the JWT correctly decoded");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_WithoutVerifySignature()
         {
             var builder = new JwtBuilder();
@@ -205,7 +206,7 @@ namespace JWT.Tests.Common
                    .NotBeEmpty("because the token should have been decoded without errors if asked so");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_ToDictionary()
         {
             var builder = new JwtBuilder();
@@ -227,7 +228,7 @@ namespace JWT.Tests.Common
                              .Be(0.ToString(), "because the key of the first claim should give its original value");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_ToDictionary_MultipleSecrets()
         {
             var builder = new JwtBuilder();
@@ -249,7 +250,7 @@ namespace JWT.Tests.Common
                              .Be(0.ToString(), "because the key of the first claim should give its original value");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToken_ToDictionary_WithoutSerializer_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
@@ -1,21 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Builder;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtBuilderEncodeTests
     {
         private readonly Fixture _fixture = new Fixture();
 
-        [Fact]
+        [TestMethod]
         public void Build_Token()
         {
             var algorithm = new HMACSHA256Algorithm();
@@ -34,7 +34,7 @@ namespace JWT.Tests.Common
                       .HaveCount(3, "because the built token should have the three standard parts");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithPayload()
         {
             var algorithm = new HMACSHA256Algorithm();
@@ -59,7 +59,7 @@ namespace JWT.Tests.Common
                       .HaveCount(3, "because the built token should have the three standard parts");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithPayloadWithClaims()
         {
             var algorithm = new HMACSHA256Algorithm();
@@ -103,7 +103,7 @@ namespace JWT.Tests.Common
                         .ContainAll(claimValues, "because all values associated with the claims should be retrieved in the token");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithoutDependencies_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -115,7 +115,7 @@ namespace JWT.Tests.Common
                                     .Throw<InvalidOperationException>("because a JWT can't be built without dependencies");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithSymmetricAlgorithm_WithoutSecret_Should_Throw_Exception()
         {
             var algorithm = new HMACSHA256Algorithm();
@@ -128,7 +128,7 @@ namespace JWT.Tests.Common
                               .Throw<InvalidOperationException>("because a JWT can't be built with a symmetric algorithm and without a secret");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithoutAlgorithm_WithSecret_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
@@ -141,7 +141,7 @@ namespace JWT.Tests.Common
                                     .Throw<InvalidOperationException>("because a JWT should not be created if no algorithm is provided");
         }
 
-        [Fact]
+        [TestMethod]
         public void Build_WithMultipleSecrets_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();

--- a/tests/JWT.Tests.Common/JwtDataTests.cs
+++ b/tests/JWT.Tests.Common/JwtDataTests.cs
@@ -2,15 +2,16 @@
 using AutoFixture;
 using FluentAssertions;
 using JWT.Builder;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtDataTests
     {
         private readonly Fixture _fixture = new Fixture();
 
-        [Fact]
+        [TestMethod]
         public void JwtData_With_Ctor_Params()
         {
             var headers = _fixture.Create<Dictionary<string, object>>();

--- a/tests/JWT.Tests.Common/JwtDecoderTests.cs
+++ b/tests/JWT.Tests.Common/JwtDecoderTests.cs
@@ -3,17 +3,17 @@ using System;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Serializers;
-using JWT.Tests.Common.Internal;
 using JWT.Tests.Common.Models;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtDecoderTests
     {
         private readonly Fixture _fixture = new Fixture();
 
-        [Fact]
+        [TestMethod]
         public void Decode_Should_Decode_Token_To_Json_Encoded_String()
         {
             var key = _fixture.Create<string>();
@@ -31,7 +31,7 @@ namespace JWT.Tests.Common
                 .Be(expected, "because the provided object should be correctly serialized in the token");
         }
 
-        [Fact]
+        [TestMethod]
         public void Decode_Should_Decode_Token_To_Json_Encoded_String_Multiple_Secrets()
         {
             var keys = _fixture.Create<string[]>();
@@ -49,7 +49,7 @@ namespace JWT.Tests.Common
                   .Be(expected, "because the provided object should be correctly serialized in the token");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Decode_Token_To_Dictionary()
         {
             var expected = TestData.DictionaryPayload;
@@ -66,7 +66,7 @@ namespace JWT.Tests.Common
                   .Equal(expected, "because the JWT should have been correctly deserialized to the correct object");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Decode_Token_To_Dictionary_Multiple_Secrets()
         {
             var expected = TestData.DictionaryPayload;
@@ -83,7 +83,7 @@ namespace JWT.Tests.Common
                   .Equal(expected, "because the JWT should have been correctly deserialized to the correct object");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Decode_Token_To_Generic_Type()
         {
             var expected = TestData.Customer;
@@ -100,7 +100,7 @@ namespace JWT.Tests.Common
                   .BeEquivalentTo(expected, "because the JWT should have been correctly deserialized to the same customer object");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Decode_Token_To_Generic_Type_Multiple_Secrets()
         {
             var expected = TestData.Customer;
@@ -117,7 +117,7 @@ namespace JWT.Tests.Common
                   .BeEquivalentTo(expected, "because the JWT should have been correctly deserialized to the same customer object");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Malformed_Token()
         {
             const string badToken = TestData.MalformedToken;
@@ -134,7 +134,7 @@ namespace JWT.Tests.Common
                             .Throw<InvalidTokenPartsException>("because the provided token does not contains the required three parts");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Malformed_Token_Multiple_Secrets()
         {
             const string badToken = TestData.MalformedToken;
@@ -151,7 +151,7 @@ namespace JWT.Tests.Common
                                             .Throw<InvalidTokenPartsException>("because the provided token does not contains the required three parts");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Invalid_Key()
         {
             const string token = TestData.Token;
@@ -169,7 +169,7 @@ namespace JWT.Tests.Common
                                  .Throw<SignatureVerificationException>("because providing the wrong key must raise an error when the signature is verified");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Invalid_Key_Multiple_Secrets()
         {
             const string token = TestData.Token;
@@ -187,7 +187,7 @@ namespace JWT.Tests.Common
                                  .Throw<SignatureVerificationException>("because providing the wrong key must raise an error when the signature is verified");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Invalid_Expiration_Claim()
         {
             var key = _fixture.Create<string>();
@@ -208,7 +208,7 @@ namespace JWT.Tests.Common
                                       .Throw<SignatureVerificationException>("because the invalid 'exp' must result in an exception on decoding");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Invalid_Expiration_Claim_MultipleKeys()
         {
             var key = _fixture.Create<string>();
@@ -231,7 +231,7 @@ namespace JWT.Tests.Common
                                       .Throw<SignatureVerificationException>("because the invalid 'exp' must result in an exception on decoding");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Null_Expiration_Claim()
         {
             var key = _fixture.Create<string>();
@@ -253,7 +253,7 @@ namespace JWT.Tests.Common
                                      .WithMessage("Claim 'exp' must be a number.", "because the invalid 'exp' must result in an exception on decoding");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Null_Expiration_Claim_MultipleKeys()
         {
             var key = _fixture.Create<string>();
@@ -277,7 +277,7 @@ namespace JWT.Tests.Common
                                      .WithMessage("Claim 'exp' must be a number.", "because the invalid 'exp' must result in an exception on decoding");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Expired_Claim()
         {
             var key = _fixture.Create<string>();
@@ -304,7 +304,7 @@ namespace JWT.Tests.Common
                             .Throw<TokenExpiredException>("because decoding an expired token should raise an exception when verified");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_DecodeToken_On_Exp_Claim_After_Year2038()
         {
             var key = _fixture.Create<string>();
@@ -328,7 +328,7 @@ namespace JWT.Tests.Common
                     .Be(actual, "because the token should be correctly decoded");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_Before_NotBefore_Becomes_Valid()
         {
             var serializer = new JsonNetSerializer();
@@ -350,7 +350,7 @@ namespace JWT.Tests.Common
                               .Throw<SignatureVerificationException>();
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Throw_Exception_On_Null_NotBefore_Claim()
         {
             var key = _fixture.Create<string>();
@@ -372,7 +372,7 @@ namespace JWT.Tests.Common
                                      .WithMessage("Claim 'nbf' must be a number.", "because the invalid 'nbf' must result in an exception on decoding");
         }
 
-        [Fact]
+        [TestMethod]
         public void DecodeToObject_Should_Decode_Token_After_NotBefore_Becomes_Valid()
         {
             var dateTimeProvider = new UtcDateTimeProvider();

--- a/tests/JWT.Tests.Common/JwtEncoderTests.cs
+++ b/tests/JWT.Tests.Common/JwtEncoderTests.cs
@@ -3,13 +3,14 @@ using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Serializers;
 using JWT.Tests.Common.Models;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtEncoderTests
     {
-        [Fact]
+        [TestMethod]
         public void Encode_Should_Encode_To_Token()
         {
             const string key = "ABC";
@@ -27,7 +28,7 @@ namespace JWT.Tests.Common
                   .Be(token, "because the same data encoded with the same key must result in the same token");
         }
 
-        [Fact]
+        [TestMethod]
         public void Encode_Should_Encode_To_Token_With_Extra_Headers()
         {
             var extraHeaders = new Dictionary<string, object>

--- a/tests/JWT.Tests.Common/JwtSecurityTests.cs
+++ b/tests/JWT.Tests.Common/JwtSecurityTests.cs
@@ -5,16 +5,17 @@ using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Serializers;
 using JWT.Tests.Common.Models;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtSecurityTests
     {
         private readonly Fixture _fixture = new Fixture();
 
-        [Fact]
-        [Trait(TestCategory.Category, TestCategory.Security)]
+        [TestMethod]
+        [TestCategory(TestCategory.Security)]
         public void Decode_Should_Throw_Exception_When_Non_Algorithm_Was_Used()
         {
             var key = _fixture.Create<string>();
@@ -32,8 +33,8 @@ namespace JWT.Tests.Common
                                     .Throw<ArgumentException>("because the decoding of a JWT without algorithm should raise an exception");
         }
 
-        [Fact]
-        [Trait(TestCategory.Category, TestCategory.Security)]
+        [TestMethod]
+        [TestCategory(TestCategory.Security)]
         public void Decode_Should_Throw_Exception_When_Non_Algorithm_Was_Used_MultipleKeys()
         {
             var keys = _fixture.Create<string[]>();
@@ -51,8 +52,8 @@ namespace JWT.Tests.Common
                                     .Throw<ArgumentException>("because the decoding of a JWT without algorithm should raise an exception");
         }
 
-        [Fact]
-        [Trait(TestCategory.Category, TestCategory.Security)]
+        [TestMethod]
+        [TestCategory(TestCategory.Security)]
         public void Decode_Should_Throw_Exception_When_HMA_Algorithm_Is_Used_But_RSA_Was_Expected()
         {
             var serializer = new JsonNetSerializer();
@@ -73,8 +74,8 @@ namespace JWT.Tests.Common
                                              .Throw<NotSupportedException>("because an encryption algorithm can't be changed another on decoding");
         }
 
-        [Fact]
-        [Trait(TestCategory.Category, TestCategory.Security)]
+        [TestMethod]
+        [TestCategory(TestCategory.Security)]
         public void Decode_Should_Throw_Exception_When_HMA_Algorithm_Is_Used_But_RSA_Was_Expected_MultipleKeys()
         {
             var serializer = new JsonNetSerializer();

--- a/tests/JWT.Tests.Common/JwtValidatorTests.cs
+++ b/tests/JWT.Tests.Common/JwtValidatorTests.cs
@@ -3,20 +3,20 @@ using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Serializers;
 using JWT.Tests.Common.Models;
-using Xunit;
-
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static JWT.Internal.EncodingHelper;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class JwtValidatorTests
     {
-        [Theory]
-        [InlineData(null, null, null)]
-        [InlineData("", null, null)]
-        [InlineData("{}", null, null)]
-        [InlineData("{}", TestData.Token, null)]
-        [InlineData("{}", TestData.Token, "")]
+        [DataTestMethod]
+        [DataRow(null, null, null)]
+        [DataRow("", null, null)]
+        [DataRow("{}", null, null)]
+        [DataRow("{}", TestData.Token, null)]
+        [DataRow("{}", TestData.Token, "")]
         public void Validate_Should_Throw_Exception_When_Argument_Is_Null_Or_Empty(string payloadJson, string decodedCrypto, string decodedSignature)
         {
             var jwtValidator = new JwtValidator(null, null);
@@ -28,7 +28,7 @@ namespace JWT.Tests.Common
                                               .Throw<ArgumentException>("because the JWT argument must not be null or empty");
         }
 
-        [Fact]
+        [TestMethod]
         public void Validate_Should_Throw_Exception_When_Crypto_Does_Not_Match_Signature()
         {
             const string token = TestData.Token;
@@ -43,7 +43,7 @@ namespace JWT.Tests.Common
             var decodedCrypto = Convert.ToBase64String(crypto);
 
             var alg = new HMACSHA256Algorithm();
-            var bytesToSign = GetBytes(string.Concat(jwt.Header, ".", jwt.Payload));
+            var bytesToSign = GetBytes(String.Concat(jwt.Header, ".", jwt.Payload));
             var signatureData = alg.Sign(GetBytes("ABC"), bytesToSign);
             ++signatureData[0]; // malformed signature
             var decodedSignature = Convert.ToBase64String(signatureData);
@@ -57,7 +57,7 @@ namespace JWT.Tests.Common
                                        .Throw<SignatureVerificationException>("because the signature does not match the crypto");
         }
 
-        [Fact]
+        [TestMethod]
         public void Validate_Should_Not_Throw_Exception_When_Crypto_Matches_Signature()
         {
             var urlEncoder = new JwtBase64UrlEncoder();
@@ -80,12 +80,12 @@ namespace JWT.Tests.Common
             jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
         }
 
-        [Theory]
-        [InlineData(null, null, null)]
-        [InlineData("", null, null)]
-        [InlineData("{}", null, null)]
-        [InlineData("{}", TestData.Token, null)]
-        [InlineData("{}", TestData.Token, "")]
+        [DataTestMethod]
+        [DataRow(null, null, null)]
+        [DataRow("", null, null)]
+        [DataRow("{}", null, null)]
+        [DataRow("{}", TestData.Token, null)]
+        [DataRow("{}", TestData.Token, "")]
         public void TryValidate_Should_Return_False_And_Exception_Not_Null_When_Argument_Is_Null_Or_Empty(string payloadJson, string decodedCrypto, string decodedSignature)
         {
             var jwtValidator = new JwtValidator(null, null);
@@ -99,7 +99,7 @@ namespace JWT.Tests.Common
               .NotBeNull("because an exception should have been thrown during the process");
         }
 
-        [Fact]
+        [TestMethod]
         public void TryValidate_Should_Return_False_And_Exception_Not_Null_When_Crypto_Matches_Signature()
         {
             var urlEncoder = new JwtBase64UrlEncoder();
@@ -114,7 +114,7 @@ namespace JWT.Tests.Common
             var decodedCrypto = Convert.ToBase64String(crypto);
 
             var alg = new HMACSHA256Algorithm();
-            var bytesToSign = GetBytes(string.Concat(jwt.Header, ".", jwt.Payload));
+            var bytesToSign = GetBytes(String.Concat(jwt.Header, ".", jwt.Payload));
             var signatureData = alg.Sign(GetBytes("ABC"), bytesToSign);
             ++signatureData[0]; // malformed signature
             var decodedSignature = Convert.ToBase64String(signatureData);
@@ -129,7 +129,7 @@ namespace JWT.Tests.Common
               .NotBeNull("because an exception should have been thrown during the process");
         }
 
-        [Fact]
+        [TestMethod]
         public void TryValidate_Should_Return_True_And_Exception_Null_When_Crypto_Matches_Signature()
         {
             var urlEncoder = new JwtBase64UrlEncoder();
@@ -144,7 +144,7 @@ namespace JWT.Tests.Common
             var decodedCrypto = Convert.ToBase64String(crypto);
 
             var alg = new HMACSHA256Algorithm();
-            var bytesToSign = GetBytes(string.Concat(jwt.Header, ".", jwt.Payload));
+            var bytesToSign = GetBytes(String.Concat(jwt.Header, ".", jwt.Payload));
             var signatureData = alg.Sign(GetBytes("ABC"), bytesToSign);
             var decodedSignature = Convert.ToBase64String(signatureData);
 

--- a/tests/JWT.Tests.Common/Models/TestCategory.cs
+++ b/tests/JWT.Tests.Common/Models/TestCategory.cs
@@ -2,8 +2,6 @@
 {
     public static class TestCategory
     {
-        public const string Category = nameof(Category);
-
         public const string Security = nameof(Security);
     }
 }

--- a/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
+++ b/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
@@ -3,15 +3,16 @@ using System.Security.Cryptography;
 using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
 {
+    [TestClass]
     public class RS256AlgorithmTests
     {
         private readonly Fixture _fixture = new Fixture();
 
-        [Fact]
+        [TestMethod]
         public void Ctor_Should_Throw_Exception_When_PublicKey_Is_Null()
         {
             var privateKey = _fixture.Create<RSACryptoServiceProvider>();
@@ -23,7 +24,7 @@ namespace JWT.Tests.Common
                                .Throw<ArgumentNullException>("because asymmetric algorithm cannot be constructed without public key");
         }
 
-        [Fact]
+        [TestMethod]
         public void Ctor_Should_Throw_Exception_When_PrivateKey_Is_Null()
         {
             var publicKey = _fixture.Create<RSACryptoServiceProvider>();
@@ -35,7 +36,7 @@ namespace JWT.Tests.Common
                                 .Throw<ArgumentNullException>("because asymmetric algorithm cannot be constructed without private key");
         }
 
-        [Fact]
+        [TestMethod]
         public void Sign_Should_Throw_Exception_When_PrivateKey_Is_Null()
         {
             var publicKey = _fixture.Create<RSACryptoServiceProvider>();

--- a/tests/JWT.Tests.Core/JWT.Tests.Core.csproj
+++ b/tests/JWT.Tests.Core/JWT.Tests.Core.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/tests/JWT.Tests.Core/JWT.Tests.Core.csproj
+++ b/tests/JWT.Tests.Core/JWT.Tests.Core.csproj
@@ -18,25 +18,17 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\JWT\JWT.csproj" />
     <ProjectReference Include="..\JWT.Tests.Common\JWT.Tests.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/JWT.Tests.Core/xunit.runner.json
+++ b/tests/JWT.Tests.Core/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https: //xunit.github.io/schema/v2.2/xunit.runner.schema.json",
-  "methodDisplay": "method"
-}

--- a/tests/JWT.Tests.NETFramework/App.config
+++ b/tests/JWT.Tests.NETFramework/App.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <appSettings>
-    <add key="xunit.methodDisplay" value="method"/>
-  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
+++ b/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
@@ -125,10 +125,10 @@
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
-  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
 </Project>

--- a/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
+++ b/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -50,6 +51,15 @@
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net47\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeCoverage.16.4.0\lib\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.0.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -63,18 +73,6 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\JWT.Tests.Common\JwtBuilderDecodeTests.cs">
@@ -117,18 +115,20 @@
       <Name>JWT.Tests.Common</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
 </Project>

--- a/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
+++ b/tests/JWT.Tests.NETFramework/JWT.Tests.NETFramework.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
@@ -125,10 +124,7 @@
     <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
   </Target>
   <Import Project="..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.0.0\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
-  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.2.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
 </Project>

--- a/tests/JWT.Tests.NETFramework/packages.config
+++ b/tests/JWT.Tests.NETFramework/packages.config
@@ -4,8 +4,8 @@
   <package id="Fare" version="2.1.2" targetFramework="net472" />
   <package id="FluentAssertions" version="5.9.0" targetFramework="net472" />
   <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net472" />
-  <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net472" />
-  <package id="Microsoft.TestPlatform.TestHost" version="16.4.0" targetFramework="net472" />
+  <package id="Microsoft.NET.Test.Sdk" version="16.2.0" targetFramework="net472" />
+  <package id="Microsoft.TestPlatform.TestHost" version="16.2.0" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />

--- a/tests/JWT.Tests.NETFramework/packages.config
+++ b/tests/JWT.Tests.NETFramework/packages.config
@@ -3,14 +3,11 @@
   <package id="AutoFixture" version="4.11.0" targetFramework="net461" />
   <package id="Fare" version="2.1.2" targetFramework="net472" />
   <package id="FluentAssertions" version="5.9.0" targetFramework="net472" />
+  <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net472" />
+  <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net472" />
+  <package id="Microsoft.TestPlatform.TestHost" version="16.4.0" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
-  <package id="xunit" version="2.4.1" targetFramework="net462" />
-  <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
-  <package id="xunit.assert" version="2.4.1" targetFramework="net462" />
-  <package id="xunit.core" version="2.4.1" targetFramework="net462" />
-  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net462" />
-  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net462" />
-  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/JWT.Tests.NETFramework/packages.config
+++ b/tests/JWT.Tests.NETFramework/packages.config
@@ -4,8 +4,6 @@
   <package id="Fare" version="2.1.2" targetFramework="net472" />
   <package id="FluentAssertions" version="5.9.0" targetFramework="net472" />
   <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net472" />
-  <package id="Microsoft.NET.Test.Sdk" version="16.2.0" targetFramework="net472" />
-  <package id="Microsoft.TestPlatform.TestHost" version="16.2.0" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.0.0" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />


### PR DESCRIPTION
Rationale:

- Functional parity
- Active development
- First-class support by Microsoft technologies and products (namely: Visual Studio)
- Familiarity of the only maintainer (myself)

Known issues:

- https://github.com/Microsoft/testfx/issues/304
- https://github.com/microsoft/testfx/issues/664