### PR TITLE
Siimplyfing methods of Decoder and Validator

### DIFF
--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -303,10 +303,13 @@ namespace JWT.Builder
         private void EnsureCanBuild()
         {
             if (!CanBuild())
-                throw new InvalidOperationException("Can't build a token. Check if you have call all of the followng methods:\r\n" +
-                                                    $"-{nameof(WithAlgorithm)}" + Environment.NewLine +
-                                                    $"-{nameof(WithSerializer)}" + Environment.NewLine +
-                                                    $"-{nameof(WithUrlEncoder)}.");
+            {
+                throw new InvalidOperationException(
+                    "Can't build a token. Check if you have call all of the following methods:" +Environment.NewLine +
+                    $"-{nameof(WithAlgorithm)}" + Environment.NewLine +
+                    $"-{nameof(WithSerializer)}" + Environment.NewLine +
+                    $"-{nameof(WithUrlEncoder)}.");
+            }
 
             if (!HasOnlyOneSecret())
                 throw new InvalidOperationException("You can't provide more than one secret to use for encoding.");
@@ -315,10 +318,13 @@ namespace JWT.Builder
         private void EnsureCanDecode()
         {
             if (!CanDecode())
-                throw new InvalidOperationException("Can't decode a token. Check if you have call all of the following methods:" + Environment.NewLine +
-                                                    $"-{nameof(WithSerializer)}" + Environment.NewLine +
-                                                    $"-{nameof(WithValidator)}" + Environment.NewLine +
-                                                    $"-{nameof(WithUrlEncoder)}.");
+            {
+                throw new InvalidOperationException(
+                    "Can't decode a token. Check if you have call all of the following methods:" + Environment.NewLine +
+                    $"-{nameof(WithSerializer)}" + Environment.NewLine +
+                    $"-{nameof(WithValidator)}" + Environment.NewLine +
+                    $"-{nameof(WithUrlEncoder)}.");
+            }
         }
 
         /// <summary>

--- a/src/JWT/IJwtDecoder.cs
+++ b/src/JWT/IJwtDecoder.cs
@@ -50,7 +50,7 @@ namespace JWT
         /// <param name="keys">The keys bytes provided which one of them was used to sign the JWT</param>
         /// <param name="verify">Whether to verify the signature (default is true)</param>
         /// <returns>A string containing the JSON payload</returns>
-        string Decode(string token, IReadOnlyCollection<byte[]> keys, bool verify);
+        string Decode(string token, byte[][] keys, bool verify);
 
         #endregion
 
@@ -104,7 +104,7 @@ namespace JWT
         /// <returns>An object representing the payload</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim</exception>
-        IDictionary<string, object> DecodeToObject(string token, IReadOnlyCollection<byte[]> keys, bool verify);
+        IDictionary<string, object> DecodeToObject(string token, byte[][] keys, bool verify);
 
         #endregion
 
@@ -164,7 +164,7 @@ namespace JWT
         /// <returns>An object representing the payload</returns>
         /// <exception cref="SignatureVerificationException">Thrown if the verify parameter was true and the signature was NOT valid or if the JWT was signed with an unsupported algorithm</exception>
         /// <exception cref="TokenExpiredException">Thrown if the verify parameter was true and the token has an expired exp claim</exception>
-        T DecodeToObject<T>(string token, IReadOnlyCollection<byte[]> keys, bool verify);
+        T DecodeToObject<T>(string token, byte[][] keys, bool verify);
 
         #endregion
     }

--- a/src/JWT/IJwtValidator.cs
+++ b/src/JWT/IJwtValidator.cs
@@ -6,16 +6,6 @@
     public interface IJwtValidator
     {
         /// <summary>
-        /// Given the JWT, verifies its signature correctness.
-        /// </summary>
-        /// <param name="payloadJson">>An arbitrary payload (already serialized to JSON)</param>
-        /// <param name="decodedCrypto">Decoded body</param>
-        /// <param name="decodedSignature">Decoded signature</param>
-        /// <exception cref="SignatureVerificationException">The signature is invalid</exception>
-        /// <exception cref="TokenExpiredException">The token has expired</exception>
-        void Validate(string payloadJson, string decodedCrypto, string decodedSignature);
-
-        /// <summary>
         /// Given the JWT, verifies its signatures correctness.
         /// </summary>
         /// <param name="payloadJson">>An arbitrary payload (already serialized to JSON)</param>
@@ -23,6 +13,6 @@
         /// <param name="decodedSignatures">Decoded signatures</param>
         /// <exception cref="SignatureVerificationException">The signature is invalid</exception>
         /// <exception cref="TokenExpiredException">The token has expired</exception>
-        void Validate(string payloadJson, string decodedCrypto, string[] decodedSignatures);
+        void Validate(string payloadJson, string decodedCrypto, params string[] decodedSignatures);
     }
 }

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -29,7 +29,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
-    <Version>5.3.1</Version>
+    <Version>5.3.2</Version>
     <FileVersion>5.0.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -29,9 +29,9 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
-    <Version>5.3.2</Version>
-    <FileVersion>5.0.0.0</FileVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <Version>6.0.0-beta1</Version>
+    <FileVersion>6.0.0.0</FileVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -200,18 +200,18 @@ namespace JWT
         }
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate(String,String,String)" />
+        /// Prepares data before calling <see cref="IJwtValidator.Validate" />
         /// </summary>
         /// <param name="parts">The array representation of a JWT</param>
         /// <param name="key">The key that was used to sign the JWT</param>
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public void Validate(string[] parts, byte[] key) =>
+        public void Validate(string[] parts, params byte[] key) =>
             Validate(new JwtParts(parts), key);
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string[])" />
+        /// Prepares data before calling <see cref="IJwtValidator.Validate" />
         /// </summary>
         /// <param name="jwt">The JWT parts</param>
         /// <param name="keys">The keys provided which one of them was used to sign the JWT</param>
@@ -226,7 +226,6 @@ namespace JWT
                 throw new ArgumentNullException(nameof(keys));
             if (keys.Length == 0 || !AllKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
-
 
             var crypto = _urlEncoder.Decode(jwt.Signature);
             var decodedCrypto = Convert.ToBase64String(crypto);

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -98,13 +98,13 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public string Decode(string token, IReadOnlyCollection<byte[]> keys, bool verify)
+        public string Decode(string token, byte[][] keys, bool verify)
         {
             if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
             if (keys is null)
                 throw new ArgumentNullException(nameof(keys));
-            if (keys.Count == 0 || !AllKeysHaveValues(keys))
+            if (keys.Length == 0 || !AllKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
 
             if (verify)
@@ -152,7 +152,7 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public IDictionary<string, object> DecodeToObject(string token, IReadOnlyCollection<byte[]> keys, bool verify) =>
+        public IDictionary<string, object> DecodeToObject(string token, byte[][] keys, bool verify) =>
             DecodeToObject<Dictionary<string, object>>(token, keys, verify);
 
         /// <inheritdoc />
@@ -193,14 +193,14 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public T DecodeToObject<T>(string token, IReadOnlyCollection<byte[]> keys, bool verify)
+        public T DecodeToObject<T>(string token, byte[][] keys, bool verify)
         {
             var payload = Decode(token, keys, verify);
             return _jsonSerializer.Deserialize<T>(payload);
         }
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string)" />
+        /// Prepares data before calling <see cref="IJwtValidator.Validate(String,String,String)" />
         /// </summary>
         /// <param name="parts">The array representation of a JWT</param>
         /// <param name="key">The key that was used to sign the JWT</param>
@@ -211,35 +211,6 @@ namespace JWT
             Validate(new JwtParts(parts), key);
 
         /// <summary>
-        /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string)" />
-        /// </summary>
-        /// <param name="jwt">The JWT parts</param>
-        /// <param name="key">The key that was used to sign the JWT</param>
-        /// <exception cref="ArgumentNullException" />
-        /// <exception cref="ArgumentOutOfRangeException" />
-        /// <exception cref="FormatException" />
-        public void Validate(JwtParts jwt, byte[] key)
-        {
-            if (jwt is null)
-                throw new ArgumentNullException(nameof(jwt));
-            if (key is null)
-                throw new ArgumentNullException(nameof(key));
-            if (key.Length == 0)
-                throw new ArgumentOutOfRangeException(nameof(key));
-
-            void ValidateImpl(string payloadJson, string decodedCrypto, IJwtAlgorithm alg, byte[] bytesToSign)
-            {
-                var signatureData = alg.Sign(key, bytesToSign);
-                var decodedSignature = Convert.ToBase64String(signatureData);
-
-                _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
-
-            }
-
-            Validate(jwt, ValidateImpl);
-        }
-
-        /// <summary>
         /// Prepares data before calling <see cref="IJwtValidator.Validate(string,string,string[])" />
         /// </summary>
         /// <param name="jwt">The JWT parts</param>
@@ -247,33 +218,15 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public void Validate(JwtParts jwt, IReadOnlyCollection<byte[]> keys)
+        public void Validate(JwtParts jwt, params byte[][] keys)
         {
             if (jwt is null)
                 throw new ArgumentNullException(nameof(jwt));
             if (keys is null)
                 throw new ArgumentNullException(nameof(keys));
-            if (keys.Count == 0 || !AllKeysHaveValues(keys))
+            if (keys.Length == 0 || !AllKeysHaveValues(keys))
                 throw new ArgumentOutOfRangeException(nameof(keys));
 
-
-            void ValidateImpl(string payloadJson, string decodedCrypto, IJwtAlgorithm alg, byte[] bytesToSign)
-            {
-                var decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign))
-                                            .Select(sd => Convert.ToBase64String(sd))
-                                            .ToArray();
-
-                _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
-
-            }
-
-            Validate(jwt, ValidateImpl);
-        }
-
-        private void Validate(JwtParts jwt, Action<string, string, IJwtAlgorithm, byte[]> validate)
-        {
-            if (jwt is null)
-                throw new ArgumentNullException(nameof(jwt));
 
             var crypto = _urlEncoder.Decode(jwt.Signature);
             var decodedCrypto = Convert.ToBase64String(crypto);
@@ -289,7 +242,11 @@ namespace JWT
             var algName = (string)headerData["alg"];
             var alg = _algFactory.Create(algName);
 
-            validate(payloadJson, decodedCrypto, alg, bytesToSign);
+            var decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign))
+                                        .Select(sd => Convert.ToBase64String(sd))
+                                        .ToArray();
+
+            _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
         }
 
         private static bool AllKeysHaveValues(IEnumerable<byte[]> keys) =>

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -292,7 +292,6 @@ namespace JWT
             validate(payloadJson, decodedCrypto, alg, bytesToSign);
         }
 
-
         private static bool AllKeysHaveValues(IEnumerable<byte[]> keys) =>
             keys.All(key => key.Any());
     }

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -28,17 +28,7 @@ namespace JWT
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
         /// <exception cref="SignatureVerificationException" />
-        public void Validate(string payloadJson, string decodedCrypto, string decodedSignature)
-        {
-            var ex = GetValidationException(payloadJson, decodedCrypto, decodedSignature);
-            if (ex != null)
-                throw ex;
-        }
-
-        /// <inheritdoc />
-        /// <exception cref="ArgumentException" />
-        /// <exception cref="SignatureVerificationException" />
-        public void Validate(string payloadJson, string decodedCrypto, string[] decodedSignatures)
+        public void Validate(string payloadJson, string decodedCrypto, params string[] decodedSignatures)
         {
             var ex = GetValidationException(payloadJson, decodedCrypto, decodedSignatures);
             if (ex != null)
@@ -130,7 +120,7 @@ namespace JWT
         /// <remarks>See https://tools.ietf.org/html/rfc7515#section-4.1.4</remarks>
         /// <exception cref="SignatureVerificationException" />
         /// <exception cref="TokenExpiredException" />
-        private static Exception ValidateExpClaim(IDictionary<string, object> payloadData, double secondsSinceEpoch)
+        private static Exception ValidateExpClaim(IReadOnlyDictionary<string, object> payloadData, double secondsSinceEpoch)
         {
             if (!payloadData.TryGetValue("exp", out var expObj))
                 return null;

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -73,24 +73,7 @@ namespace JWT
             return ex is null;
         }
 
-        private Exception GetValidationException(string payloadJson, string decodedCrypto, string decodedSignature)
-        {
-            if (String.IsNullOrWhiteSpace(payloadJson))
-                return new ArgumentException(nameof(payloadJson));
-
-            if (String.IsNullOrWhiteSpace(decodedCrypto))
-                return new ArgumentException(nameof(decodedCrypto));
-
-            if (String.IsNullOrWhiteSpace(decodedSignature))
-                return new ArgumentException(nameof(decodedSignature));
-
-            if (!CompareCryptoWithSignature(decodedCrypto, decodedSignature))
-                return new SignatureVerificationException(decodedCrypto, decodedSignature);
-
-            return GetValidationException(payloadJson);
-        }
-
-        private Exception GetValidationException(string payloadJson, string decodedCrypto, string[] decodedSignatures)
+        private Exception GetValidationException(string payloadJson, string decodedCrypto, params string[] decodedSignatures)
         {
             if (String.IsNullOrWhiteSpace(payloadJson))
                 return new ArgumentException(nameof(payloadJson));
@@ -123,7 +106,7 @@ namespace JWT
         private static bool IsAnySignatureValid(string decodedCrypto, IEnumerable<string> decodedSignatures) =>
             decodedSignatures.Any(decodedSignature => CompareCryptoWithSignature(decodedCrypto, decodedSignature));
 
-        /// <remarks>In the future this method can be opened for extension so made protected virtual</remarks>
+        /// <remarks>In the future this method can be opened for extension thus made protected virtual</remarks>
         private static bool CompareCryptoWithSignature(string decodedCrypto, string decodedSignature)
         {
             if (decodedCrypto.Length != decodedSignature.Length)

--- a/src/JWT/TokenExpiredException.cs
+++ b/src/JWT/TokenExpiredException.cs
@@ -23,7 +23,7 @@ namespace JWT
         /// <summary>
         /// The payload.
         /// </summary>
-        public IDictionary<string, object> PayloadData
+        public IReadOnlyDictionary<string, object> PayloadData
         {
             get => GetOrDefault<Dictionary<string, object>>(PayloadDataKey);
             internal set => this.Data.Add(PayloadDataKey, value);


### PR DESCRIPTION
- Replacing methods `Validate(string, string, string)` and `Validate(string, string, string[])` with single `Validate(string, string, params string[])`
- Bumping version to 6.0.0-beta1