### PR TITLE
RS256 ctor can accept cert with no private key

### DIFF
--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -42,14 +42,7 @@ namespace JWT.Algorithms
         /// <param name="cert">The certificate having a public key and an optional private key.</param>
         public RS256Algorithm(X509Certificate2 cert)
         {
-            if (cert is null)
-            {
-                throw new ArgumentNullException(nameof(cert));
-            }
-
             _publicKey = GetPublicKey(cert) ?? throw new Exception("Certificate's PublicKey cannot be null.");
-
-            // Optional / can be null.
             _privateKey = GetPrivateKey(cert);
         }
 
@@ -86,6 +79,9 @@ namespace JWT.Algorithms
 
         private static RSA GetPrivateKey(X509Certificate2 cert)
         {
+            if (cert is null)
+                throw new ArgumentNullException(nameof(cert));
+
 #if NETSTANDARD1_3
             return cert.GetRSAPrivateKey();
 #else
@@ -95,6 +91,9 @@ namespace JWT.Algorithms
 
         private static RSA GetPublicKey(X509Certificate2 cert)
         {
+            if (cert is null)
+                throw new ArgumentNullException(nameof(cert));
+
 #if NETSTANDARD1_3
             return cert.GetRSAPublicKey();
 #else

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -39,10 +39,18 @@ namespace JWT.Algorithms
         /// <summary>
         /// Creates an instance using the provided certificate.
         /// </summary>
-        /// <param name="cert">The certificate having both public and private keys.</param>
+        /// <param name="cert">The certificate having a public key and an optional private key.</param>
         public RS256Algorithm(X509Certificate2 cert)
-            : this(GetPublicKey(cert), GetPrivateKey(cert))
         {
+            if (cert is null)
+            {
+                throw new ArgumentNullException(nameof(cert));
+            }
+
+            _publicKey = GetPublicKey(cert) ?? throw new Exception("Certificate's PublicKey cannot be null.");
+
+            // Optional / can be null.
+            _privateKey = GetPrivateKey(cert);
         }
 
         /// <inheritdoc />

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -15,7 +15,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>6.0.0-beta2</Version>
+    <Version>6.0.0-beta3</Version>
     <FileVersion>6.0.0.0</FileVersion>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
+++ b/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
@@ -67,12 +67,13 @@ namespace JWT.Tests.Common
         [DataTestMethod]
         [DataRow(TestData.ServerRsaPublicKey1)]
         [DataRow(TestData.ServerRsaPublicKey2)]
-        public void Ctor_Should_Not_Throw_Exception_When_PublicCertificate_Has_No_PrivateKey(string publicKey)
+        public void Ctor_Should_Not_Throw_Exception_When_Certificate_Has_No_PrivateKey(string publicKey)
         {
             var bytes = Encoding.ASCII.GetBytes(publicKey);
             var certificate = new X509Certificate2(bytes);
 
             var algorithm = new RS256Algorithm(certificate);
+
             algorithm.Should().NotBeNull();
         }
     }

--- a/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
+++ b/tests/JWT.Tests.Common/RS256AlgorithmTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
+using JWT.Tests.Common.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
@@ -49,6 +52,28 @@ namespace JWT.Tests.Common
 
             signWithoutPrivateKey.Should()
                                  .Throw<InvalidOperationException>("because asymmetric algorithm cannot sign data without private key");
+        }
+
+        [TestMethod]
+        public void Ctor_Should_Not_Throw_Exception_When_PublicKeyHasNoPrivateKey()
+        {
+            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+
+            var algorithm = new RS256Algorithm(publicKey);
+
+            algorithm.Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow(TestData.ServerRsaPublicKey1)]
+        [DataRow(TestData.ServerRsaPublicKey2)]
+        public void Ctor_Should_Not_Throw_Exception_When_PublicCertificate_Has_No_PrivateKey(string publicKey)
+        {
+            var bytes = Encoding.ASCII.GetBytes(publicKey);
+            var certificate = new X509Certificate2(bytes);
+
+            var algorithm = new RS256Algorithm(certificate);
+            algorithm.Should().NotBeNull();
         }
     }
 }


### PR DESCRIPTION
- I'm not sure how to create a certificate _without_ a public key. (I would like to test this scenario, if it's doable).
- Included some tests for
  - Certificate has public key only.
  - RS256Algorithm can be created with only a public key (existing code, just adding a simple test).