### PR TITLE
Make AddCalims accept an IReadOnlyDictionary

### DIFF
--- a/src/JWT/Builder/JwtBuilderExtensions.cs
+++ b/src/JWT/Builder/JwtBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace JWT.Builder
         /// <summary>
         /// Adds several claims to the JWT
         /// </summary>
-        public static JwtBuilder AddClaims(this JwtBuilder builder, IDictionary<string, object> claims) =>
+        public static JwtBuilder AddClaims(this JwtBuilder builder, IReadOnlyDictionary<string, object> claims) =>
             claims.Aggregate(builder, (b, p) => b.AddClaim(p.Key, p.Value));
 
         public static JwtBuilder ExpirationTime(this JwtBuilder builder, DateTime time) =>

--- a/src/JWT/Builder/JwtBuilderExtensions.cs
+++ b/src/JWT/Builder/JwtBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace JWT.Builder
         /// <summary>
         /// Adds several claims to the JWT
         /// </summary>
-        public static JwtBuilder AddClaims(this JwtBuilder builder, IReadOnlyDictionary<string, object> claims) =>
+        public static JwtBuilder AddClaims(this JwtBuilder builder, IEnumerable<KeyValuePair<string, object>> claims) =>
             claims.Aggregate(builder, (b, p) => b.AddClaim(p.Key, p.Value));
 
         public static JwtBuilder ExpirationTime(this JwtBuilder builder, DateTime time) =>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -16,8 +16,8 @@
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
     <Version>6.0.1</Version>
-    <FileVersion>6.0.1.0</FileVersion>
-    <AssemblyVersion>6.0.1.0</AssemblyVersion>
+    <FileVersion>6.0.0.0</FileVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -15,9 +15,9 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>6.0.0</Version>
-    <FileVersion>6.0.0.0</FileVersion>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion>
+    <Version>6.0.1</Version>
+    <FileVersion>6.0.1.0</FileVersion>
+    <AssemblyVersion>6.0.1.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
The `AddClaims()` method does not modify the payload in any way. We can use `IReadOnlyDictionary` instead of ordinary `IDictionary`.