### PR TITLE
Made secret optional in Decode() to support asymmetric algorithms

### DIFF
--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -15,7 +15,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>6.1.1</Version>
+    <Version>6.1.2</Version>
     <FileVersion>6.0.0.0</FileVersion>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -220,8 +220,19 @@ namespace JWT
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
-        public void Validate(string[] parts, params byte[] key) =>
+        public void Validate(string[] parts, byte[] key) =>
             Validate(new JwtParts(parts), key);
+
+        /// <summary>
+        /// Prepares data before calling <see cref="IJwtValidator.Validate" />
+        /// </summary>
+        /// <param name="parts">The array representation of a JWT</param>
+        /// <param name="keys">The keys provided which one of them was used to sign the JWT</param>
+        /// <exception cref="ArgumentNullException" />
+        /// <exception cref="ArgumentOutOfRangeException" />
+        /// <exception cref="FormatException" />
+        public void Validate(string[] parts, params byte[][] keys) =>
+            Validate(new JwtParts(parts), keys);
 
         /// <summary>
         /// Prepares data before calling <see cref="IJwtValidator.Validate" />

--- a/src/JWT/JwtDecoder.cs
+++ b/src/JWT/JwtDecoder.cs
@@ -51,6 +51,9 @@ namespace JWT
         /// <exception cref="FormatException" />
         public string Decode(JwtParts jwt)
         {
+            if (jwt is null)
+                throw new ArgumentNullException(nameof(jwt));
+
             var decoded = _urlEncoder.Decode(jwt.Payload);
             return GetString(decoded);
         }
@@ -85,38 +88,34 @@ namespace JWT
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
-        /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public string Decode(string token, byte[] key, bool verify)
         {
             if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
-            if (key is null)
-                throw new ArgumentNullException(nameof(key));
-            if (key.Length == 0)
+            if (key is object && key.Length == 0)
                 throw new ArgumentOutOfRangeException(nameof(key));
+
+            var jwt = new JwtParts(token);
 
             if (verify)
             {
-                Validate(new JwtParts(token), key);
+                Validate(jwt, key);
             }
 
-            return Decode(token);
+            return Decode(jwt);
         }
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException" />
-        /// <exception cref="ArgumentNullException" />
         /// <exception cref="ArgumentOutOfRangeException" />
         /// <exception cref="FormatException" />
         public string Decode(string token, byte[][] keys, bool verify)
         {
             if (String.IsNullOrWhiteSpace(token))
                 throw new ArgumentException(nameof(token));
-            if (keys is null)
-                throw new ArgumentNullException(nameof(keys));
-            if (keys.Length == 0 || !AllKeysHaveValues(keys))
+            if (keys is object && (keys.Length == 0 || !AllKeysHaveValues(keys)))
                 throw new ArgumentOutOfRangeException(nameof(keys));
 
             var jwt = new JwtParts(token);
@@ -236,9 +235,7 @@ namespace JWT
         {
             if (jwt is null)
                 throw new ArgumentNullException(nameof(jwt));
-            if (keys is null)
-                throw new ArgumentNullException(nameof(keys));
-            if (keys.Length == 0 || !AllKeysHaveValues(keys))
+            if (keys is object && (keys.Length == 0 || !AllKeysHaveValues(keys)))
                 throw new ArgumentOutOfRangeException(nameof(keys));
 
             var crypto = _urlEncoder.Decode(jwt.Signature);
@@ -255,11 +252,19 @@ namespace JWT
             var algName = (string)headerData["alg"];
             var alg = _algFactory.Create(algName);
 
-            var decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign))
-                                        .Select(sd => Convert.ToBase64String(sd))
-                                        .ToArray();
-
-            _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
+            if (keys is object)
+            {
+                var decodedSignatures = keys.Select(key => alg.Sign(key, bytesToSign))
+                                            .Select(sd => Convert.ToBase64String(sd))
+                                            .ToArray();
+                _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignatures);
+            }
+            else
+            {
+                var bytesSigned = alg.Sign(null, bytesToSign);
+                var decodedSignature = Convert.ToBase64String(bytesSigned);
+                _jwtValidator.Validate(payloadJson, decodedCrypto, decodedSignature);
+            }
         }
 
         private static bool AllKeysHaveValues(IEnumerable<byte[]> keys) =>

--- a/tests/JWT.Tests.Common/JwtBuilderDecodeTests.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderDecodeTests.cs
@@ -12,7 +12,7 @@ namespace JWT.Tests.Common
     public class JwtBuilderDecodeTests
     {
         [TestMethod]
-        public void DecodeToken()
+        public void Decode_Should_Return_Token()
         {
             var builder = new JwtBuilder();
 
@@ -24,34 +24,34 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutAlgorithm_Should_Throw_Exception()
+        public void Decode_Without_Algorithm_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodingWithoutAlgorithm =
+            Action action =
                 () => builder.WithAlgorithm(null)
                              .Decode(TestData.Token);
 
-            decodingWithoutAlgorithm.Should()
-                                    .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid algorithm");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid algorithm");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutAlgorithmFactory_Should_Throw_Exception()
+        public void Decode_Without_AlgorithmFactory_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodingWithoutAlgorithm =
+            Action action =
                 () => builder.WithAlgorithm(null)
                              .WithAlgorithmFactory(null)
                              .Decode(TestData.Token);
 
-            decodingWithoutAlgorithm.Should()
-                                    .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid algorithm or algorithm factory");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid algorithm or algorithm factory");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutToken_Should_Throw_Exception()
+        public void Decode_Without_Token_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
@@ -60,24 +60,24 @@ namespace JWT.Tests.Common
                              .Decode(null);
 
             decodingANullJwt.Should()
-                            .Throw<ArgumentException>("because null is not a valid value for a TestData.Token");
+                            .Throw<ArgumentException>("because null is not valid value for token");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutSerializer_Should_Throw_Exception()
+        public void Decode_Without_Serializer_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodeJwtWithNullSerializer =
+            Action action =
                 () => builder.WithSerializer(null)
                              .Decode(TestData.Token);
 
-            decodeJwtWithNullSerializer.Should()
-                                       .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid serializer");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid serializer");
         }
 
         [TestMethod]
-        public void DecodeToken_WithSerializer()
+        public void Decode_With_Serializer_Should_Return_Token()
         {
             var builder = new JwtBuilder();
             var serializer = new JsonNetSerializer();
@@ -87,25 +87,25 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because the TestData.Token should be correctly decoded and its data extracted");
+                   .NotBeEmpty("because token should be correctly decoded and its data extracted");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutUrlEncoder_Should_Throw_Exception()
+        public void Decode_Without_UrlEncoder_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodeJwtWithNullEncoder =
+            Action action =
                 () => builder.WithAlgorithm(TestData.HMACSHA256Algorithm)
                              .WithUrlEncoder(null)
                              .Decode(TestData.Token);
 
-            decodeJwtWithNullEncoder.Should()
-                                    .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid UrlEncoder");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid UrlEncoder");
         }
 
         [TestMethod]
-        public void DecodeToken_WithUrlEncoder()
+        public void Decode_With_UrlEncoder_Should_Return_Token()
         {
             var builder = new JwtBuilder();
             var urlEncoder = new JwtBase64UrlEncoder();
@@ -115,25 +115,25 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because the TestData.Token should have been correctly decoded with the valid base 64 encoder");
+                   .NotBeEmpty("because token should have been correctly decoded with the valid base 64 encoder");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutTimeProvider_Should_Throw_Exception()
+        public void Decode_Without_TimeProvider_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodingJwtWithNullDateTimeProvider =
+            Action action =
                 () => builder.WithAlgorithm(TestData.HMACSHA256Algorithm)
                              .WithDateTimeProvider(null)
                              .Decode(TestData.Token);
 
-            decodingJwtWithNullDateTimeProvider.Should()
-                                               .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid DateTimeProvider");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid DateTimeProvider");
         }
 
         [TestMethod]
-        public void DecodeToken_WithDateTimeProvider()
+        public void Decode_With_DateTimeProvider_Should_Return_Token()
         {
             var builder = new JwtBuilder();
             var dateTimeProvider = new UtcDateTimeProvider();
@@ -144,11 +144,11 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because the decoding process must be successful with a valid DateTimeProvider");
+                   .NotBeEmpty("because the decoding process must be successful with valid DateTimeProvider");
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutValidator()
+        public void Decode_Without_Validator_Should_Return_Token()
         {
             var builder = new JwtBuilder();
 
@@ -157,11 +157,11 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because a JWT should not necessary have a validator to be decoded");
+                   .NotBeEmpty("because a JWT should not necessary have validator to be decoded");
         }
 
         [TestMethod]
-        public void DecodeToken_WithExplicitValidator()
+        public void Decode_With_ExplicitValidator_Should_Return_Token()
         {
             var builder = new JwtBuilder();
             var validator = new JwtValidator(
@@ -173,11 +173,11 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because a JWT should be correctly decoded, even with a validator");
+                   .NotBeEmpty("because a JWT should be correctly decoded, even with validator");
         }
 
         [TestMethod]
-        public void DecodeToken_WithVerifySignature()
+        public void Decode_With_VerifySignature_Should_Return_Token()
         {
             var builder = new JwtBuilder();
 
@@ -191,7 +191,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void DecodeToken_WithVerifySignature_MultipleSecrets()
+        public void Decode_With_VerifySignature_With_Multiple_Secrets_Should_Return_Token()
         {
             var builder = new JwtBuilder();
 
@@ -205,7 +205,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void DecodeToken_WithoutVerifySignature()
+        public void Decode_Without_VerifySignature_Should_Return_Token()
         {
             var builder = new JwtBuilder();
 
@@ -214,11 +214,25 @@ namespace JWT.Tests.Common
                                  .Decode(TestData.Token);
 
             payload.Should()
-                   .NotBeEmpty("because the TestData.Token should have been decoded without errors if asked so");
+                   .NotBeEmpty("because token should have been decoded without errors");
         }
 
         [TestMethod]
-        public void DecodeToken_ToDictionary()
+        public void Decode_With_VerifySignature_Without_PrivateKey_Should_Throw_Exception()
+        {
+            var builder = new JwtBuilder();
+
+            Action action =
+                () => builder.WithAlgorithm(TestData.RS256Algorithm)
+                             .MustVerifySignature()
+                             .Decode(TestData.Token);
+
+            action.Should()
+                  .Throw<InvalidOperationException>("because validating signature requires private key");
+        }
+
+        [TestMethod]
+        public void Decode_To_Dictionary_Should_Return_Dictionary()
         {
             var builder = new JwtBuilder();
 
@@ -234,7 +248,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void DecodeToken_ToDictionary_MultipleSecrets()
+        public void Decode_ToDictionary_With_Multiple_Secrets_Should_Return_Dictionary()
         {
             var builder = new JwtBuilder();
 
@@ -250,7 +264,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void DecodeToken_ToObject_MultipleSecrets()
+        public void Decode_ToObject_With_Multiple_Secrets_Should_Return_Object()
         {
             var builder = new JwtBuilder();
 
@@ -263,21 +277,20 @@ namespace JWT.Tests.Common
             payload.Age.Should().Be(33);
         }
 
-
         [TestMethod]
-        public void DecodeToken_ToDictionary_WithoutSerializer_Should_Throw_Exception()
+        public void Decode_ToDictionary_Without_Serializer_Should_Throw_Exception()
         {
             var builder = new JwtBuilder();
 
-            Action decodeJwtWithNullSerializer =
+            Action action =
                 () => builder.WithAlgorithm(TestData.HMACSHA256Algorithm)
                              .WithSerializer(null)
                              .WithSecret(TestData.Secret)
                              .MustVerifySignature()
                              .Decode<Dictionary<string, string>>(TestData.Token);
 
-            decodeJwtWithNullSerializer.Should()
-                                       .Throw<InvalidOperationException>("because a TestData.Token can't be decoded without a valid serializer");
+            action.Should()
+                  .Throw<InvalidOperationException>("because token can't be decoded without valid serializer");
         }
     }
 }

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace JWT.Tests.Common
 {
     [TestClass]
-    public partial class JwtBuilderEncodeTests
+    public class JwtBuilderEncodeTests
     {
         private static readonly Fixture _fixture = new Fixture();
 

--- a/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
+++ b/tests/JWT.Tests.Common/JwtBuilderEncodeTests.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Builder;
-using JWT.Tests.Common.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JWT.Tests.Common
@@ -19,7 +16,7 @@ namespace JWT.Tests.Common
         private static readonly Fixture _fixture = new Fixture();
 
         [TestMethod]
-        public void Encode_With_Secret()
+        public void Encode_With_Secret_Should_Return_Token()
         {
             var algorithm = new HMACSHA256Algorithm();
             var builder = new JwtBuilder();
@@ -37,7 +34,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void Encode_With_Secret_And_Payload()
+        public void Encode_With_Secret_And_Payload_Should_Return_Token()
         {
             var algorithm = new HMACSHA256Algorithm();
             var builder = new JwtBuilder();
@@ -60,7 +57,7 @@ namespace JWT.Tests.Common
         }
 
         [TestMethod]
-        public void Encode_With_PayloadWithClaims()
+        public void Encode_With_PayloadWithClaims_Should_Return_Token()
         {
             var algorithm = new HMACSHA256Algorithm();
             var claims = new Dictionary<string, object>();

--- a/tests/JWT.Tests.Core3/JwtBuilderEndToEndTests.cs
+++ b/tests/JWT.Tests.Core3/JwtBuilderEndToEndTests.cs
@@ -20,12 +20,11 @@ namespace JWT.Tests.Core3
             using var rsa = RSA.Create();
             rsa.FromXmlString(TestData.ServerRsaPrivateKey);
 
-            using var pubOnly = new X509Certificate2(Encoding.ASCII.GetBytes(TestData.ServerRsaPublicKey2));
-            using var pubPrivEphemeral = pubOnly.CopyWithPrivateKey(rsa);
-            using var cert = new X509Certificate2(pubPrivEphemeral.Export(X509ContentType.Pfx));
+            using var certPub = new X509Certificate2(Encoding.ASCII.GetBytes(TestData.ServerRsaPublicKey2));
+            using var certPubPriv = new X509Certificate2(certPub.CopyWithPrivateKey(rsa).Export(X509ContentType.Pfx));
 
             var builder = new JwtBuilder();
-            var algorithm = new RS256Algorithm(cert);
+            var algorithm = new RS256Algorithm(certPubPriv);
 
             const string iss = "test";
             var exp = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds();

--- a/tests/JWT.Tests.Core3/JwtBuilderEndToEndTests.cs
+++ b/tests/JWT.Tests.Core3/JwtBuilderEndToEndTests.cs
@@ -9,9 +9,10 @@ using JWT.Builder;
 using JWT.Tests.Common.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace JWT.Tests.Common
+namespace JWT.Tests.Core3
 {
-    public partial class JwtBuilderEncodeTests
+    [TestClass]
+    public class JwtBuilderEndToEndTests
     {
         [TestMethod]
         public void Encode_and_Decode_With_Certificate()
@@ -45,7 +46,6 @@ namespace JWT.Tests.Common
                  .HaveCount(3, "because the built token should have the three standard parts");
 
             var jwt = builder.WithAlgorithm(algorithm)
-                             .WithSecret(TestData.ServerRsaPublicKey2)
                              .MustVerifySignature()
                              .Decode<Dictionary<string, object>>(token);
 


### PR DESCRIPTION
Continuation of #258, cc @stefansolid.

* Made secret optional in Decode() to support asymmetric algorithms
* Bumped version to 6.1.2