### PR TITLE
Fixed sample code in readme to use Encode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Console.WriteLine(token);
       .WithSecret(secret)
       .AddClaim("exp", DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds())
       .AddClaim("claim2", "claim2-value")
-      .Build();
+      .Encode();
 
 Console.WriteLine(token);
 ```


### PR DESCRIPTION
Sample code for Encoding using the Fluent API in the ReadMe was still using Build() which is obsolete instead of Encode().  Fixed.

Thanks for the great and easy to use library!