### PR TITLE
Fix typo of 'AuthenticationTicket' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-#### Custom factories to produce Identity or AuthneticationTicket
+#### Custom factories to produce Identity or AuthenticationTicket
 
 ```c#
 options.IdentityFactory = dic => new ClaimsIdentity(


### PR DESCRIPTION
Noticed this typo while I was reading through your docs. Obviously a minor issue but figured I'd toss in a PR 