### PR TITLE
Various performance and memory allocation optimizations

### DIFF
--- a/src/JWT/Algorithms/ES256Algorithm.cs
+++ b/src/JWT/Algorithms/ES256Algorithm.cs
@@ -41,7 +41,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.ES256.ToString();
+        public override string Name => nameof(JwtAlgorithmName.ES256);
 
         // <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA256;

--- a/src/JWT/Algorithms/ES384Algorithm.cs
+++ b/src/JWT/Algorithms/ES384Algorithm.cs
@@ -41,7 +41,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.ES384.ToString();
+        public override string Name => nameof(JwtAlgorithmName.ES384);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA384;

--- a/src/JWT/Algorithms/ES512Algorithm.cs
+++ b/src/JWT/Algorithms/ES512Algorithm.cs
@@ -41,7 +41,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.ES512.ToString();
+        public override string Name => nameof(JwtAlgorithmName.ES512);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA512;

--- a/src/JWT/Algorithms/HMACSHA256Algorithm.cs
+++ b/src/JWT/Algorithms/HMACSHA256Algorithm.cs
@@ -8,7 +8,7 @@ namespace JWT.Algorithms
     public sealed class HMACSHA256Algorithm : HMACSHAAlgorithm
     {
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.HS256.ToString();
+        public override string Name => nameof(JwtAlgorithmName.HS256);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA256;

--- a/src/JWT/Algorithms/HMACSHA384Algorithm.cs
+++ b/src/JWT/Algorithms/HMACSHA384Algorithm.cs
@@ -8,7 +8,7 @@ namespace JWT.Algorithms
     public sealed class HMACSHA384Algorithm : HMACSHAAlgorithm
     {
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.HS384.ToString();
+        public override string Name => nameof(JwtAlgorithmName.HS384);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA384;

--- a/src/JWT/Algorithms/HMACSHA512Algorithm.cs
+++ b/src/JWT/Algorithms/HMACSHA512Algorithm.cs
@@ -8,7 +8,7 @@ namespace JWT.Algorithms
     public sealed class HMACSHA512Algorithm : HMACSHAAlgorithm
     {
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.HS512.ToString();
+        public override string Name => nameof(JwtAlgorithmName.HS512);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA512;

--- a/src/JWT/Algorithms/RS256Algorithm.cs
+++ b/src/JWT/Algorithms/RS256Algorithm.cs
@@ -40,7 +40,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.RS256.ToString();
+        public override string Name => nameof(JwtAlgorithmName.RS256);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA256;

--- a/src/JWT/Algorithms/RS384Algorithm.cs
+++ b/src/JWT/Algorithms/RS384Algorithm.cs
@@ -40,7 +40,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.RS384.ToString();
+        public override string Name => nameof(JwtAlgorithmName.RS384);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA384;

--- a/src/JWT/Algorithms/RS512Algorithm.cs
+++ b/src/JWT/Algorithms/RS512Algorithm.cs
@@ -40,7 +40,7 @@ namespace JWT.Algorithms
         }
 
         /// <inheritdoc />
-        public override string Name => JwtAlgorithmName.RS512.ToString();
+        public override string Name => nameof(JwtAlgorithmName.RS512);
 
         /// <inheritdoc />
         public override HashAlgorithmName HashAlgorithmName => HashAlgorithmName.SHA512;

--- a/src/JWT/Builder/EnumExtensions.cs
+++ b/src/JWT/Builder/EnumExtensions.cs
@@ -24,9 +24,9 @@ namespace JWT.Builder
         {
             var valueString = value.ToString();
             return value.GetType()
-                .GetField(valueString)
-                .GetCustomAttribute<DescriptionAttribute>()
-                ?.Description ?? valueString;
+                        .GetField(valueString)
+                        .GetCustomAttribute<DescriptionAttribute>()
+                       ?.Description ?? valueString;
         }
     }
 }

--- a/src/JWT/Builder/EnumExtensions.cs
+++ b/src/JWT/Builder/EnumExtensions.cs
@@ -20,10 +20,13 @@ namespace JWT.Builder
         /// <summary>
         /// Gets the value of the <see cref="DescriptionAttribute" /> from the object.
         /// </summary>
-        private static string GetDescription<T>(T value) =>
-            value.GetType()
-                 .GetField(value.ToString())
-                 .GetCustomAttribute<DescriptionAttribute>()
-                ?.Description ?? value.ToString();
+        private static string GetDescription<T>(T value)
+        {
+            var valueString = value.ToString();
+            return value.GetType()
+                .GetField(valueString)
+                .GetCustomAttribute<DescriptionAttribute>()
+                ?.Description ?? valueString;
+        }
     }
 }

--- a/src/JWT/Builder/JwtData.cs
+++ b/src/JWT/Builder/JwtData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using JWT.Exceptions;
+using JWT.Internal;
 
 namespace JWT.Builder
 {
@@ -43,8 +44,8 @@ namespace JWT.Builder
         /// <param name="token">The JWT token</param>
         public JwtData(string token)
         {
-            var partsOfToken = token.Split('.');
-            if (partsOfToken.Length != 3)
+            var partsOfTokenCount = token.Count('.');
+            if (partsOfTokenCount != 3)
                 throw new InvalidTokenPartsException(nameof(token));
         }
 

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -1,16 +1,21 @@
-#if NET35
 using System;
 
 namespace JWT.Compatibility
 {
     internal static class String
     {
+#if !NETSTANDARD
+        /// <remarks>
+        /// The overload accpting char is missing outside .NET Standard.
+        /// See https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netstandard-2.0#System_String_IndexOf_System_String_System_StringComparison_
+        /// </remarks>
         public static int IndexOf(this string value, char ch, StringComparison comparisonType)
         {
-            // ignores comparisonType since the overload is missing in .NET 3.5
-            return value.IndexOf(ch);
+            return value.IndexOf(ch.ToString(), comparisonType);
         }
-    
+#end
+  
+#if NET35
         public static bool IsNullOrWhiteSpace(string value)
         {
             if (!string.IsNullOrEmpty(value))
@@ -23,5 +28,5 @@ namespace JWT.Compatibility
             return true;
         }
     }
-}
 #endif
+}

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -5,7 +5,7 @@ namespace JWT.Compatibility
 {
     internal static class String
     {
-        public int IndexOf(string value, char ch, StringComparison comparisonType)
+        public int IndexOf(this string value, char ch, StringComparison comparisonType)
         {
             // ignores comparisonType since the overload is missing in .NET 3.5
             return value.IndexOf(ch);

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -1,8 +1,16 @@
-﻿#if NET35
+#if NET35
+using System;
+
 namespace JWT.Compatibility
 {
     internal static class String
     {
+        public int IndexOf(string value, char ch, StringComparison comparisonType)
+        {
+            // ignores comparisonType since the overload is missing in .NET 3.5
+            return value.IndexOf(ch);
+        }
+    
         public static bool IsNullOrWhiteSpace(string value)
         {
             if (!string.IsNullOrEmpty(value))

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -5,7 +5,7 @@ namespace JWT.Compatibility
 {
     internal static class String
     {
-        public int IndexOf(this string value, char ch, StringComparison comparisonType)
+        public static int IndexOf(this string value, char ch, StringComparison comparisonType)
         {
             // ignores comparisonType since the overload is missing in .NET 3.5
             return value.IndexOf(ch);

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -27,6 +27,6 @@ namespace JWT.Compatibility
             }
             return true;
         }
-    }
 #endif
+    }
 }

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -13,7 +13,7 @@ namespace JWT.Compatibility
         {
             return value.IndexOf(ch.ToString(), comparisonType);
         }
-#end
+#endif
   
 #if NET35
         public static bool IsNullOrWhiteSpace(string value)

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -4,7 +4,7 @@ namespace JWT.Compatibility
 {
     internal static class String
     {
-#if !NETSTANDARD
+#if !NETSTANDARD2_0
         /// <remarks>
         /// The overload accpting char is missing outside .NET Standard.
         /// See https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netstandard-2.0#System_String_IndexOf_System_String_System_StringComparison_

--- a/src/JWT/Compatibility/String.cs
+++ b/src/JWT/Compatibility/String.cs
@@ -1,32 +1,20 @@
-using System;
-
+#if NET35
 namespace JWT.Compatibility
 {
     internal static class String
     {
-#if !NETSTANDARD2_0
-        /// <remarks>
-        /// The overload accpting char is missing outside .NET Standard.
-        /// See https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netstandard-2.0#System_String_IndexOf_System_String_System_StringComparison_
-        /// </remarks>
-        public static int IndexOf(this string value, char ch, StringComparison comparisonType)
-        {
-            return value.IndexOf(ch.ToString(), comparisonType);
-        }
-#endif
-  
-#if NET35
         public static bool IsNullOrWhiteSpace(string value)
         {
             if (!string.IsNullOrEmpty(value))
             {
                 foreach (var ch in value)
                 {
-                    if (!char.IsWhiteSpace(ch)) return false;
+                    if (!char.IsWhiteSpace(ch))
+                        return false;
                 }
             }
             return true;
         }
-#endif
     }
 }
+#endif

--- a/src/JWT/Exceptions/InvalidTokenPartsException.cs
+++ b/src/JWT/Exceptions/InvalidTokenPartsException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JWT.Exceptions
 {

--- a/src/JWT/Exceptions/InvalidTokenPartsException.cs
+++ b/src/JWT/Exceptions/InvalidTokenPartsException.cs
@@ -3,7 +3,7 @@
 namespace JWT.Exceptions
 {
     /// <summary>
-    /// Represents an exception thrown when when a token doesn't consist of 3 delimited by dot parts.
+    /// Represents an exception thrown when a token doesn't consist of 3 delimited by dot parts.
     /// </summary>
     public class InvalidTokenPartsException : ArgumentOutOfRangeException
     {

--- a/src/JWT/Internal/EncodingHelper.cs
+++ b/src/JWT/Internal/EncodingHelper.cs
@@ -1,4 +1,8 @@
-﻿using System.Text;
+using System.Text;
+
+#if !NETSTANDARD
+using JWT.Compatibility;
+#endif
 
 namespace JWT.Internal
 {
@@ -6,10 +10,10 @@ namespace JWT.Internal
     {
         private static readonly UTF8Encoding utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-        internal static byte[] GetBytes(string input) =>
+        public static byte[] GetBytes(string input) =>
             utf8Encoding.GetBytes(input);
 
-        internal static byte[] GetBytes(string input1, byte separator, string input2)
+        public static byte[] GetBytes(string input1, byte separator, string input2)
         {
             byte[] output = new byte[utf8Encoding.GetByteCount(input1) + utf8Encoding.GetByteCount(input2) + 1];
             int bytesWritten = utf8Encoding.GetBytes(input1, 0, input1.Length, output, 0);
@@ -18,7 +22,7 @@ namespace JWT.Internal
             return output;
         }
 
-        internal static byte[][] GetBytes(string[] input)
+        public static byte[][] GetBytes(string[] input)
         {
             byte[][] results = new byte[input.Length][];
             for (int i = 0; i < input.Length; i++)
@@ -28,7 +32,7 @@ namespace JWT.Internal
             return results;
         }
 
-        internal static string GetString(byte[] bytes) =>
+        public static string GetString(byte[] bytes) =>
             utf8Encoding.GetString(bytes);
     }
 }

--- a/src/JWT/Internal/EncodingHelper.cs
+++ b/src/JWT/Internal/EncodingHelper.cs
@@ -1,9 +1,5 @@
 using System.Text;
 
-#if !NETSTANDARD
-using JWT.Compatibility;
-#endif
-
 namespace JWT.Internal
 {
     internal static class EncodingHelper

--- a/src/JWT/Internal/EncodingHelper.cs
+++ b/src/JWT/Internal/EncodingHelper.cs
@@ -1,18 +1,34 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 
 namespace JWT.Internal
 {
     internal static class EncodingHelper
     {
-        internal static byte[] GetBytes(string input) =>
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(input);
+        private static readonly UTF8Encoding utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-        internal static byte[][] GetBytes(IEnumerable<string> input) =>
-            input.Select(GetBytes).ToArray();
+        internal static byte[] GetBytes(string input) =>
+            utf8Encoding.GetBytes(input);
+
+        internal static byte[] GetBytes(string input1, byte separator, string input2)
+        {
+            byte[] output = new byte[utf8Encoding.GetByteCount(input1) + utf8Encoding.GetByteCount(input2) + 1];
+            int bytesWritten = utf8Encoding.GetBytes(input1, 0, input1.Length, output, 0);
+            output[bytesWritten++] = separator;
+            utf8Encoding.GetBytes(input2, 0, input2.Length, output, bytesWritten);
+            return output;
+        }
+
+        internal static byte[][] GetBytes(string[] input)
+        {
+            byte[][] results = new byte[input.Length][];
+            for (int i = 0; i < input.Length; i++)
+            {
+                results[i] = GetBytes(input[i]);
+            }
+            return results;
+        }
 
         internal static string GetString(byte[] bytes) =>
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetString(bytes);
+            utf8Encoding.GetString(bytes);
     }
 }

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -1,20 +1,18 @@
-﻿namespace JWT.Internal
+using System;
+
+namespace JWT.Internal
 {
     internal static class StringHelper
     {
         internal static string FirstSegment(this string input, char separator)
         {
-            int idx = input.IndexOf(separator);
-            if (idx != -1)
-            {
-                return input.Substring(0, idx);
-            }
-            return input;
+            var idx = input.IndexOf(separator, StringComparison.OrdinalIgnoreCase);
+            return idx != -1 ? input.Substring(0, idx): input;
         }
 
         internal static int Count(this string input, char character)
         {
-            int counter = 0;
+            var counter = 0;
             for (int i = 0; i < input.Length; i++)
             {
                 if (input[i] == character)

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -4,13 +4,13 @@ namespace JWT.Internal
 {
     internal static class StringHelper
     {
-        internal static string FirstSegment(this string input, char separator)
+        public static string FirstSegment(this string input, char separator)
         {
             var idx = input.IndexOf(separator, StringComparison.OrdinalIgnoreCase);
             return idx != -1 ? input.Substring(0, idx): input;
         }
 
-        internal static int Count(this string input, char character)
+        public static int Count(this string input, char character)
         {
             var counter = 0;
             for (int i = 0; i < input.Length; i++)

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -1,5 +1,9 @@
 using System;
 
+#if !NETSTANDARD
+using JWT.Compatibility;
+#endif
+
 namespace JWT.Internal
 {
     internal static class StringHelper

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -1,16 +1,12 @@
 using System;
 
-#if !NETSTANDARD2_0
-using JWT.Compatibility;
-#endif
-
 namespace JWT.Internal
 {
     internal static class StringHelper
     {
         public static string FirstSegment(this string input, char separator)
         {
-            var idx = input.IndexOf(separator, StringComparison.OrdinalIgnoreCase);
+            var idx = input.IndexOf(separator);
             return idx != -1 ? input.Substring(0, idx): input;
         }
 

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -1,6 +1,6 @@
 using System;
 
-#if !NETSTANDARD
+#if !NETSTANDARD2_0
 using JWT.Compatibility;
 #endif
 

--- a/src/JWT/Internal/StringHelper.cs
+++ b/src/JWT/Internal/StringHelper.cs
@@ -1,0 +1,28 @@
+﻿namespace JWT.Internal
+{
+    internal static class StringHelper
+    {
+        internal static string FirstSegment(this string input, char separator)
+        {
+            int idx = input.IndexOf(separator);
+            if (idx != -1)
+            {
+                return input.Substring(0, idx);
+            }
+            return input;
+        }
+
+        internal static int Count(this string input, char character)
+        {
+            int counter = 0;
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (input[i] == character)
+                {
+                    counter++;
+                }
+            }
+            return counter;
+        }
+    }
+}

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>8.1.6</Version>
+    <Version>8.2.0</Version>
     <FileVersion>8.0.0.0</FileVersion>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>8.2.0</Version>
+    <Version>8.1.6</Version>
     <FileVersion>8.0.0.0</FileVersion>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -18,7 +18,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>8.1.5</Version>
+    <Version>8.1.6</Version>
     <FileVersion>8.0.0.0</FileVersion>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/src/JWT/JwtBase64UrlEncoder.cs
+++ b/src/JWT/JwtBase64UrlEncoder.cs
@@ -1,4 +1,5 @@
 using System;
+using JWT.Internal;
 
 #if NET35
 using static JWT.Compatibility.String;
@@ -24,7 +25,7 @@ namespace JWT
                 throw new ArgumentOutOfRangeException(nameof(input));
 
             var output = Convert.ToBase64String(input);
-            output = output.Split('=')[0]; // Remove any trailing '='s
+            output = output.FirstSegment('='); // Remove any trailing '='s
             output = output.Replace('+', '-'); // 62nd char of encoding
             output = output.Replace('/', '_'); // 63rd char of encoding
             return output;

--- a/src/JWT/JwtEncoder.cs
+++ b/src/JWT/JwtEncoder.cs
@@ -18,8 +18,8 @@ namespace JWT
         /// <summary>
         /// Creates an instance of <see cref="JwtEncoder" />
         /// </summary>
-        /// <param name="jsonSerializer">The Json Serializer</param>
         /// <param name="algorithm">The Jwt Algorithm</param>
+        /// <param name="jsonSerializer">The Json Serializer</param>
         /// <param name="urlEncoder">The Base64 URL Encoder</param>
         public JwtEncoder(IJwtAlgorithm algorithm, IJsonSerializer jsonSerializer, IBase64UrlEncoder urlEncoder)
         {
@@ -40,7 +40,7 @@ namespace JWT
             var header = extraHeaders is null ?
                 new Dictionary<string, object>(2, StringComparer.OrdinalIgnoreCase) :
                 new Dictionary<string, object>(extraHeaders, StringComparer.OrdinalIgnoreCase);
-            
+
             if (!header.ContainsKey("typ"))
                 header.Add("typ", "JWT");
             header.Add("alg", _algorithm.Name);

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -126,11 +126,11 @@ namespace JWT
             return ValidateExpClaim(payloadData, secondsSinceEpoch) ?? ValidateNbfClaim(payloadData, secondsSinceEpoch);
         }
 
-        private static bool AreAllDecodedSignaturesNullOrWhiteSpace(IEnumerable<string> decodedSignatures) =>
-            decodedSignatures.All(sgn => IsNullOrWhiteSpace(sgn));
+        private static bool AreAllDecodedSignaturesNullOrWhiteSpace(string[] decodedSignatures) =>
+            Array.TrueForAll(decodedSignatures, sgn => IsNullOrWhiteSpace(sgn));
 
-        private static bool IsAnySignatureValid(string decodedCrypto, IEnumerable<string> decodedSignatures) =>
-            decodedSignatures.Any(decodedSignature => CompareCryptoWithSignature(decodedCrypto, decodedSignature));
+        private static bool IsAnySignatureValid(string decodedCrypto, string[] decodedSignatures) =>
+            Array.Exists(decodedSignatures, decodedSignature => CompareCryptoWithSignature(decodedCrypto, decodedSignature));
 
         /// <remarks>In the future this method can be opened for extension hence made protected virtual</remarks>
         private static bool CompareCryptoWithSignature(string decodedCrypto, string decodedSignature)


### PR DESCRIPTION
- changed call ToString() on enums, and used nameof as this produce const string at compilation time, so const can be processed by JIT in a more efficient way
- reused result of `value.ToString()` in EnumExtensions.GetDescription method
- reduced allocation of unnecessary string.Split result array in JwtData and JwtBase64UrlEncoder
- reused UTF8Encoding instance in EncodingHelper, as I believe it won't change after first usage
- introduced a new method GetBytes in EncodingHelper that allows join two strings directly into bytes array
- reduced Linq usage where it could be replaced with type-specific methods with equivalent behaviour
- reduced yields by joining two Linq Select calls in JwtDecoder.Validate method
- minor comments fixes
- changed version of JWT project to 8.1.6