### PR TITLE
Use `X509Certificate2.GetRSAPublicKey` in all supported TargetFrameworks

### DIFF
--- a/src/JWT/Algorithms/RSAlgorithm.cs
+++ b/src/JWT/Algorithms/RSAlgorithm.cs
@@ -86,7 +86,7 @@ namespace JWT.Algorithms
             if (cert is null)
                 throw new ArgumentNullException(nameof(cert));
 
-#if NETSTANDARD1_3
+#if NETSTANDARD || NET || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
             return cert.GetRSAPrivateKey();
 #else
             return (RSA)cert.PrivateKey;
@@ -98,7 +98,7 @@ namespace JWT.Algorithms
             if (cert is null)
                 throw new ArgumentNullException(nameof(cert));
 
-#if NETSTANDARD1_3
+#if NETSTANDARD || NET || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
             return cert.GetRSAPublicKey();
 #else
             return (RSA)cert.PublicKey.Key;

--- a/src/JWT/Algorithms/RSAlgorithm.cs
+++ b/src/JWT/Algorithms/RSAlgorithm.cs
@@ -86,7 +86,7 @@ namespace JWT.Algorithms
             if (cert is null)
                 throw new ArgumentNullException(nameof(cert));
 
-#if NETSTANDARD || NET || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
+#if NETSTANDARD || NET || NETCOREAPP || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
             return cert.GetRSAPrivateKey();
 #else
             return (RSA)cert.PrivateKey;
@@ -98,7 +98,7 @@ namespace JWT.Algorithms
             if (cert is null)
                 throw new ArgumentNullException(nameof(cert));
 
-#if NETSTANDARD || NET || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
+#if NETSTANDARD || NET || NETCOREAPP || NETFRAMEWORK && (NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48)
             return cert.GetRSAPublicKey();
 #else
             return (RSA)cert.PublicKey.Key;

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -21,7 +21,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json</PackageTags>
     <PackageLicense>CC0-1.0</PackageLicense>
-    <Version>8.2.1</Version>
+    <Version>8.2.2</Version>
     <FileVersion>8.0.0.0</FileVersion>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>


### PR DESCRIPTION
This addresses https://github.com/jwt-dotnet/jwt/issues/328 .

The existing preprocessor directive only uses `X509Certificate2.GetRSA...Key()` if targetting NETSTANDARD1_3.

Based on https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.rsacertificateextensions.getrsapublickey?view=net-5.0 , these two methods are supported everywhere except in NETFramework < 4.6

This PR changes the preprocessor branching to list all target frameworks that support `X509Certificate2.GetRSA...Key()`:
* Any netstandard, netcore or net versions
* netframework >= 4.6, that is: 46, 461, 462, 47, 471, 472, 48