### PR TITLE
Fixing typos in exception messages

### DIFF
--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -359,7 +359,7 @@ namespace JWT.Builder
             if (!CanEncode())
             {
                 throw new InvalidOperationException(
-                    "Can't encode a token. Check if you have call all of the following methods:" + Environment.NewLine +
+                    "Can't encode a token. Check if you have called all of the following methods:" + Environment.NewLine +
                     $"-{nameof(WithAlgorithm)}" + Environment.NewLine +
                     $"-{nameof(WithSerializer)}" + Environment.NewLine +
                     $"-{nameof(WithUrlEncoder)}.");
@@ -374,7 +374,7 @@ namespace JWT.Builder
             if (!CanDecode())
             {
                 throw new InvalidOperationException(
-                    "Can't decode a token. Check if you have call all of the following methods:" + Environment.NewLine +
+                    "Can't decode a token. Check if you have called all of the following methods:" + Environment.NewLine +
                     $"-{nameof(WithSerializer)}" + Environment.NewLine +
                     $"-{nameof(WithValidator)}" + Environment.NewLine +
                     $"-{nameof(WithUrlEncoder)}.");

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -389,7 +389,7 @@ namespace JWT.Builder
             if (!CanDecodeHeader())
             {
                 throw new InvalidOperationException(
-                    "Can't decode a token header. Check if you have call all of the following methods:" + Environment.NewLine +
+                    "Can't decode a token header. Check if you have called all of the following methods:" + Environment.NewLine +
                     $"-{nameof(WithSerializer)}" + Environment.NewLine +
                     $"-{nameof(WithUrlEncoder)}.");
             }


### PR DESCRIPTION
I was trying out your lovely framework, however got a few exceptions, and noticed a typo in the message. I wanted to help by fixing them :) 