### PR TITLE
Fixed tests, build on Arch Linux

### DIFF
--- a/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
+++ b/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Builder;
@@ -10,12 +9,12 @@ namespace JWT.Tests.Algorithms
     [TestClass]
     public class RSAlgorithmFactoryTests
     {
-        private static readonly Fixture _fixture = new Fixture();
+        private static RSACryptoServiceProvider RSACryptoServiceProvider => new();
 
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS256Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS256()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -33,7 +32,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS384Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS384()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -51,7 +50,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS512Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS512()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -69,7 +68,8 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS1024Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS1024()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
+            
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -87,7 +87,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS2048Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS2048()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -105,7 +105,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS4096Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS4096()
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {

--- a/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
+++ b/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
@@ -30,7 +30,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS384Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS384()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -66,7 +66,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS1024Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS1024()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext

--- a/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
+++ b/tests/JWT.Tests.Common/Algorithms/RSAlgorithmFactoryTests.cs
@@ -9,12 +9,10 @@ namespace JWT.Tests.Algorithms
     [TestClass]
     public class RSAlgorithmFactoryTests
     {
-        private static RSACryptoServiceProvider RSACryptoServiceProvider => new();
-
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS256Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS256()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -50,7 +48,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS512Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS512()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -87,7 +85,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS2048Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS2048()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {
@@ -105,7 +103,7 @@ namespace JWT.Tests.Algorithms
         [TestMethod]
         public void Create_Should_Return_Instance_Of_RS4096Algorithm_When_Algorithm_Specified_In_Jwt_Header_Is_RS4096()
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var factory = new RSAlgorithmFactory(publicKey);
             var context = new JwtDecoderContext
             {

--- a/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs
+++ b/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Tests.Models;
@@ -13,13 +12,13 @@ namespace JWT.Tests.Algorithms
     [TestClass]
     public class RSAlgorithmTests
     {
-        private static readonly Fixture _fixture = new Fixture();
+        private static RSACryptoServiceProvider RSACryptoServiceProvider => new();
 
         [DynamicData(nameof(GetFactoryWithPublicPrivateKey), DynamicDataSourceType.Method)]
         [DataTestMethod]
         public void Ctor_Should_Throw_Exception_When_PublicKey_Is_Null(Func<RSA, RSA, RSAlgorithm> algFactory)
         {
-            var privateKey = _fixture.Create<RSACryptoServiceProvider>();
+            var privateKey = RSACryptoServiceProvider;
 
             Action action = () => algFactory(null, privateKey);
 
@@ -31,7 +30,7 @@ namespace JWT.Tests.Algorithms
         [DataTestMethod]
         public void Ctor_Should_Throw_Exception_When_PrivateKey_Is_Null(Func<RSA, RSA, RSAlgorithm> algFactory)
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
 
             Action action = () => algFactory(publicKey, null);
 
@@ -43,7 +42,7 @@ namespace JWT.Tests.Algorithms
         [DataTestMethod]
         public void Sign_Should_Throw_Exception_When_PrivateKey_Is_Null(Func<RSA, RSAlgorithm> algFactory)
         {
-            var publicKey = _fixture.Create<RSACryptoServiceProvider>();
+            var publicKey = RSACryptoServiceProvider;
             var alg = algFactory(publicKey);
 
             var bytesToSign = Array.Empty<byte>();

--- a/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs
+++ b/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs
@@ -12,13 +12,11 @@ namespace JWT.Tests.Algorithms
     [TestClass]
     public class RSAlgorithmTests
     {
-        private static RSACryptoServiceProvider RSACryptoServiceProvider => new();
-
         [DynamicData(nameof(GetFactoryWithPublicPrivateKey), DynamicDataSourceType.Method)]
         [DataTestMethod]
         public void Ctor_Should_Throw_Exception_When_PublicKey_Is_Null(Func<RSA, RSA, RSAlgorithm> algFactory)
         {
-            var privateKey = RSACryptoServiceProvider;
+            var privateKey = new RSACryptoServiceProvider();
 
             Action action = () => algFactory(null, privateKey);
 
@@ -30,7 +28,7 @@ namespace JWT.Tests.Algorithms
         [DataTestMethod]
         public void Ctor_Should_Throw_Exception_When_PrivateKey_Is_Null(Func<RSA, RSA, RSAlgorithm> algFactory)
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
 
             Action action = () => algFactory(publicKey, null);
 
@@ -42,7 +40,7 @@ namespace JWT.Tests.Algorithms
         [DataTestMethod]
         public void Sign_Should_Throw_Exception_When_PrivateKey_Is_Null(Func<RSA, RSAlgorithm> algFactory)
         {
-            var publicKey = RSACryptoServiceProvider;
+            var publicKey = new RSACryptoServiceProvider();
             var alg = algFactory(publicKey);
 
             var bytesToSign = Array.Empty<byte>();


### PR DESCRIPTION
Will probably be needed for #407 

Unless this fix is applied the tests fail with this error when running on arch linux:

```
Test method JWT.Tests.Algorithms.RSAlgorithmTests.Ctor_Should_Throw_Exception_When_PrivateKey_Is_Null threw exception: 
AutoFixture.ObjectCreationExceptionWithPath: AutoFixture was unable to create an instance from System.Security.Cryptography.RSACryptoServiceProvider because creation unexpectedly failed with exception. Please refer to the inner exception to investigate the root cause of the failure.

Request path:
	System.Security.Cryptography.RSACryptoServiceProvider

Inner exception messages:
	System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
	  System.Security.Cryptography.CryptographicException: Specified key is not a valid size for this algorithm.

 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.Security.Cryptography.CryptographicException: Specified key is not a valid size for this algorithm.
    at System.Security.Cryptography.AsymmetricAlgorithm.set_KeySize(Int32 value)
   at System.Security.Cryptography.RSAImplementation.RSAOpenSsl.set_KeySize(Int32 value)
   at System.Security.Cryptography.RSACryptoServiceProvider.set_KeySize(Int32 value)
--- End of inner exception stack trace ---
    at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.InvokeOneParameter(Object obj, BindingFlags invokeAttr, Binder binder, Object parameter, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
--- End of inner exception stack trace ---
    at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenBuilder builder)
   at JWT.Tests.Algorithms.RSAlgorithmTests.get_RSACryptoServiceProvider() in /home/markus/code/jwt/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs:line 21
   at JWT.Tests.Algorithms.RSAlgorithmTests.Ctor_Should_Throw_Exception_When_PrivateKey_Is_Null(Func`3 algFactory) in /home/markus/code/jwt/tests/JWT.Tests.Common/Algorithms/RSAlgorithmTests.cs:line 41

```