### PR TITLE
Added option to select serializer

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,14 +4,8 @@
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0'">
       <PropertyGroup>
-        <DefineConstants>$(DefineConstants);SYSTEM_TEXT_JSON</DefineConstants>
+        <DefineConstants>$(DefineConstants);MODERN_DOTNET</DefineConstants>
       </PropertyGroup>
     </When>
-    <Otherwise>
-      <PropertyGroup>
-        <DefineConstants>$(DefineConstants);NEWTONSOFT_JSON</DefineConstants>
-      </PropertyGroup>
-    </Otherwise>
   </Choose>
-
 </Project>

--- a/src/JWT.Extensions.AspNetCore/JWT.Extensions.AspNetCore.csproj
+++ b/src/JWT.Extensions.AspNetCore/JWT.Extensions.AspNetCore.csproj
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Condition="$(DefineConstants.Contains(SYSTEM_TEXT_JSON))" Include="System.Text.Json" Version="6.0.4" />
-    <PackageReference Condition="$(DefineConstants.Contains(NEWTONSOFT_JSON))" Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Condition="$(DefineConstants.Contains(MODERN_DOTNET))" Include="System.Text.Json" Version="6.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JWT.Extensions.DependencyInjection/JWT.Extensions.DependencyInjection.csproj
+++ b/src/JWT.Extensions.DependencyInjection/JWT.Extensions.DependencyInjection.csproj
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.25" />
-    <PackageReference Condition="$(DefineConstants.Contains(SYSTEM_TEXT_JSON))" Include="System.Text.Json" Version="6.0.4" />
-    <PackageReference Condition="$(DefineConstants.Contains(NEWTONSOFT_JSON))" Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Condition="$(DefineConstants.Contains(MODERN_DOTNET))" Include="System.Text.Json" Version="6.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JWT.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/JWT.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using JWT.Algorithms;
 using JWT.Internal;
+using JWT.Serializers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-
-#if SYSTEM_TEXT_JSON
-using JsonSerializer = JWT.Serializers.SystemTextSerializer;
-#elif NEWTONSOFT_JSON
-using JsonSerializer = JWT.Serializers.JsonNetSerializer;
-#endif
 
 namespace JWT
 {
@@ -17,7 +12,7 @@ namespace JWT
         public static IServiceCollection AddJwtEncoder(this IServiceCollection services)
         {
             services.TryAddSingleton<IJwtEncoder, JwtEncoder>();
-            services.TryAddSingleton<IJsonSerializer, JsonSerializer>();
+            services.TryAddSingleton(JsonSerializerFactory.Serializer);
             services.TryAddSingleton<IBase64UrlEncoder, JwtBase64UrlEncoder>();
 
             return services;
@@ -44,7 +39,7 @@ namespace JWT
         public static IServiceCollection AddJwtDecoder(this IServiceCollection services)
         {
             services.TryAddSingleton<IJwtDecoder, JwtDecoder>();
-            services.TryAddSingleton<IJsonSerializer, JsonSerializer>();
+            services.TryAddSingleton(JsonSerializerFactory.Serializer);
             services.TryAddSingleton<IJwtValidator, JwtValidator>();
             services.TryAddSingleton<IBase64UrlEncoder, JwtBase64UrlEncoder>();
             services.TryAddSingleton<IDateTimeProvider, UtcDatetimeProvider>();

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -78,6 +78,9 @@ namespace JWT.Builder
         public JwtBuilder WithSerializer(IJsonSerializer serializer)
         {
             _serializer = serializer;
+#if MODERN_DOTNET
+            Serializer = serializer;
+#endif
             return this;
         }
 

--- a/src/JWT/Builder/JwtHeader.cs
+++ b/src/JWT/Builder/JwtHeader.cs
@@ -1,6 +1,6 @@
-#if SYSTEM_TEXT_JSON
+#if MODERN_DOTNET
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
-#elif NEWTONSOFT_JSON
+#else
 using Newtonsoft.Json;
 #endif
 

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -38,8 +38,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="$(DefineConstants.Contains(SYSTEM_TEXT_JSON))" Include="System.Text.Json" Version="6.0.4" />
-    <PackageReference Condition="$(DefineConstants.Contains(NEWTONSOFT_JSON))" Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Condition="$(DefineConstants.Contains(MODERN_DOTNET))" Include="System.Text.Json" Version="6.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/JWT/Serializers/Converters/DictionaryStringObjectJsonConverter.cs
+++ b/src/JWT/Serializers/Converters/DictionaryStringObjectJsonConverter.cs
@@ -1,4 +1,4 @@
-#if SYSTEM_TEXT_JSON
+#if MODERN_DOTNET
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/JWT/Serializers/JsonNetSerializer.cs
+++ b/src/JWT/Serializers/JsonNetSerializer.cs
@@ -1,5 +1,4 @@
-﻿#if NEWTONSOFT_JSON
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
@@ -61,4 +60,3 @@ namespace JWT.Serializers
         }
     }
 }
-#endif

--- a/src/JWT/Serializers/JsonSerializerFactory.cs
+++ b/src/JWT/Serializers/JsonSerializerFactory.cs
@@ -1,16 +1,28 @@
 ﻿namespace JWT.Serializers
 {
-    internal static class JsonSerializerFactory
+    public static class JsonSerializerFactory
     {
-        public static IJsonSerializer CreateSerializer()
+        private static IJsonSerializer _serializer;
+
+        public static IJsonSerializer Serializer
         {
-#if SYSTEM_TEXT_JSON
-            return new SystemTextSerializer();
-#elif NEWTONSOFT_JSON
-            return new JsonNetSerializer();
+            get
+            {
+#if MODERN_DOTNET
+                return _serializer ??= new SystemTextSerializer();
 #else
-            throw new System.NotSupportedException();
+                
+                return _serializer ??= new JsonNetSerializer();
+#endif
+            }
+#if MODERN_DOTNET
+            set
+            {
+                _serializer = value;
+            }
 #endif
         }
+
+        public static IJsonSerializer CreateSerializer() => Serializer;
     }
 }

--- a/src/JWT/Serializers/SystemTextSerializer.cs
+++ b/src/JWT/Serializers/SystemTextSerializer.cs
@@ -1,4 +1,4 @@
-#if SYSTEM_TEXT_JSON
+#if MODERN_DOTNET
 using System;
 using System.Text.Json;
 using JWT.Serializers.Converters;

--- a/tests/JWT.Tests.Common/Builder/JwtBuilderEncodeTests.cs
+++ b/tests/JWT.Tests.Common/Builder/JwtBuilderEncodeTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -7,6 +7,7 @@ using AutoFixture;
 using FluentAssertions;
 using JWT.Algorithms;
 using JWT.Builder;
+using JWT.Serializers;
 using JWT.Tests.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/tests/JWT.Tests.Common/Builder/JwtBuilderEncodeTests.cs
+++ b/tests/JWT.Tests.Common/Builder/JwtBuilderEncodeTests.cs
@@ -327,6 +327,24 @@ namespace JWT.Tests.Builder
                  .NotBeNullOrEmpty("because the token should contains some data");
         }
 
+        [TestMethod]
+        public void Encode_With_Secret_Should_Return_Valid_Token_Using_Json_Net()
+        {
+            var secret = _fixture.Create<string>();
+
+            var token = JwtBuilder.Create()
+                .WithAlgorithm(TestData.HMACSHA256Algorithm)
+                .WithSecret(secret)
+                .WithSerializer(new JsonNetSerializer())
+                .Encode();
+
+            token.Should()
+                .NotBeNullOrEmpty("because the token should contains some data");
+            token.Split('.')
+                .Should()
+                .HaveCount(3, "because the token should consist of three parts");
+        }
+        
         private sealed class CustomFactory : IAlgorithmFactory
         {
             public IJwtAlgorithm Create(JwtDecoderContext context) =>

--- a/tests/JWT.Tests.Common/JwtEncoderTests.cs
+++ b/tests/JWT.Tests.Common/JwtEncoderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using JWT.Algorithms;
+using JWT.Serializers;
 using JWT.Tests.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -90,6 +91,24 @@ namespace JWT.Tests
 
             actual.Should()
                   .Be(expected, "because the same data encoded with the same key must result in the same token");
+        }
+        
+        [TestMethod]
+        public void Encode_Should_Encode_To_Token_Using_Json_Net()
+        {
+            const string key = TestData.Secret;
+            var toEncode = TestData.Customer;
+            const string expected = TestData.Token;
+
+            var algorithm = new HMACSHA256Algorithm();
+            var urlEncoder = new JwtBase64UrlEncoder();
+            var serializer = new JsonNetSerializer();
+            var encoder = new JwtEncoder(algorithm, serializer, urlEncoder);
+
+            var actual = encoder.Encode(toEncode, key);
+
+            actual.Should()
+                .Be(expected, "because the same data encoded with the same key must result in the same token");
         }
     }
 }

--- a/tests/JWT.Tests.Common/SerializerTests.cs
+++ b/tests/JWT.Tests.Common/SerializerTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using JWT.Serializers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JWT.Tests
+{
+    [TestClass]
+    public class SerializerTests
+    {
+        [TestMethod]
+        public void Serializer_Should_Use_Correct_Default()
+        {
+            var serializer = JsonSerializerFactory.Serializer;
+            Console.WriteLine(serializer.GetType().Name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #420 

* Changed so we always import JSON.net and added conditional just for System.Text.Json on newer dotnets.
* Opened up the JsonSerializerFactory so we can set another serializer if wanted.

I wanted to create a simple test for checking that the correct class was used as default.
I however noted that all tests returned it was using SystemTextSerializer even on the older dotnets.
See the Serializer_Should_Use_Correct_Default test.
