### PR TITLE
DictionaryStringObjectJsonConverter is only needed when deserializing

### DIFF
--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -20,7 +20,7 @@
     <Authors>Alexander Batishchev, John Sheehan, Michael Lehenbauer</Authors>
     <PackageTags>jwt;json;authorization</PackageTags>
     <PackageLicenseExpression>CC0-1.0</PackageLicenseExpression>
-    <Version>10.0.0-beta10</Version>
+    <Version>10.0.0-beta11</Version>
     <FileVersion>10.0.0.0</FileVersion>
     <AssemblyVersion>10.0.0.0</AssemblyVersion>
     <RootNamespace>JWT</RootNamespace>

--- a/src/JWT/Serializers/Converters/DictionaryStringObjectJsonConverter.cs
+++ b/src/JWT/Serializers/Converters/DictionaryStringObjectJsonConverter.cs
@@ -1,9 +1,6 @@
 #if MODERN_DOTNET
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -40,100 +37,8 @@ namespace JWT.Serializers.Converters
 
         public override void Write(Utf8JsonWriter writer, Dictionary<string, object> value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            foreach (var key in value.Keys)
-            {
-                HandleValue(writer, key, value[key]);
-            }
-            writer.WriteEndObject();
+            throw new NotSupportedException("Use the built in logic for serializing to json.");
         }
-
-        private static void HandleValue(Utf8JsonWriter writer, string key, object objectValue)
-        {
-            if (key is object)
-                writer.WritePropertyName(key);
-
-            switch (objectValue)
-            {
-                case string stringValue:
-                {
-                    writer.WriteStringValue(stringValue);
-                    break;
-                }
-                case DateTime dateTime:
-                {
-                    writer.WriteStringValue(dateTime);
-                    break;
-                }
-                case long longValue:
-                {
-                    writer.WriteNumberValue(longValue);
-                    break;
-                }
-                case int intValue:
-                {
-                    writer.WriteNumberValue(intValue);
-                    break;
-                }
-                case float floatValue:
-                {
-                    writer.WriteNumberValue(floatValue);
-                    break;
-                }
-                case double doubleValue:
-                {
-                    writer.WriteNumberValue(doubleValue);
-                    break;
-                }
-                case decimal decimalValue:
-                {
-                    writer.WriteNumberValue(decimalValue);
-                    break;
-                }
-                case bool boolValue:
-                {
-                    writer.WriteBooleanValue(boolValue);
-                    break;
-                }
-                case Dictionary<string, object> dic:
-                {
-                    writer.WriteStartObject();
-                    foreach (var item in dic)
-                    {
-                        HandleValue(writer, item.Key, item.Value);
-                    }
-                    writer.WriteEndObject();
-                    break;
-                }
-                case IEnumerable enumerable:
-                {
-                    writer.WriteStartArray();
-                    foreach (var item in enumerable)
-                    {
-                        HandleValue(writer, item);
-                    }
-
-                    writer.WriteEndArray();
-                    break;
-                }                    
-                default:
-                {
-                    var dic = objectValue.GetType()
-                                         .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                                         .ToDictionary(p => p.Name, p => p.GetValue(objectValue, null));
-                    writer.WriteStartObject();
-                    foreach (var p in dic)
-                    {
-                        HandleValue(writer, p.Key, p.Value);
-                    }
-                    writer.WriteEndObject();
-                    break;
-                }
-            }
-        }
-
-        private static void HandleValue(Utf8JsonWriter writer, object value) =>
-            HandleValue(writer, null, value);
 
         private object ExtractValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {

--- a/src/JWT/Serializers/SystemTextSerializer.cs
+++ b/src/JWT/Serializers/SystemTextSerializer.cs
@@ -10,7 +10,7 @@ namespace JWT.Serializers
     /// </summary>
     public class SystemTextSerializer : IJsonSerializer
     {
-        private static readonly JsonSerializerOptions _optionsForSserialize = new JsonSerializerOptions();
+        private static readonly JsonSerializerOptions _optionsForSerialize = new JsonSerializerOptions();
 
         private static readonly JsonSerializerOptions _optionsForDeserialize = new JsonSerializerOptions
         {
@@ -27,7 +27,7 @@ namespace JWT.Serializers
             if (obj is null)
                 throw new ArgumentNullException(nameof(obj));
 
-            return JsonSerializer.Serialize(obj, _optionsForSserialize);
+            return JsonSerializer.Serialize(obj, _optionsForSerialize);
         }
 
 

--- a/src/JWT/Serializers/SystemTextSerializer.cs
+++ b/src/JWT/Serializers/SystemTextSerializer.cs
@@ -10,7 +10,9 @@ namespace JWT.Serializers
     /// </summary>
     public class SystemTextSerializer : IJsonSerializer
     {
-        private static readonly JsonSerializerOptions _options = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions _optionsForSserialize = new JsonSerializerOptions();
+
+        private static readonly JsonSerializerOptions _optionsForDeserialize = new JsonSerializerOptions
         {
             Converters =
             {
@@ -25,7 +27,7 @@ namespace JWT.Serializers
             if (obj is null)
                 throw new ArgumentNullException(nameof(obj));
 
-            return JsonSerializer.Serialize(obj, _options);
+            return JsonSerializer.Serialize(obj, _optionsForSserialize);
         }
 
 
@@ -39,7 +41,7 @@ namespace JWT.Serializers
             if (String.IsNullOrEmpty(json))
                 throw new ArgumentException(nameof(json));
 
-            return JsonSerializer.Deserialize(json, type, _options);
+            return JsonSerializer.Deserialize(json, type, _optionsForDeserialize);
         }
     }
 }


### PR DESCRIPTION
I posted about our finding of the bug #439 in the repo from where I found the code for handling Dictionary<string, object> serialization.

https://github.com/joseftw/JOS.STJ.DictionaryStringObjectJsonConverter/issues/2

Apparently the converter is only needed when reading serialized data so we can cleanup our code a bit.

