### PR TITLE
Added note about breaking changes in 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@
 
 # 10.0.0
 
-- **Breaking:** System.Text.Json is now the default serializer
+- **Breaking:** Made System.Text.Json the default serializer on the platforms where it's available
+- **Breaking:** Made verify=true by default in IJwtDecoder methods
+
 - Made NoneAlgorithm not requiring any keys as it is not signed
 - Added option to select default serializer, Newtonsoft.Json or System.Text.Json (#433)
 - Renamed default IdentityFactory in Jwt.Extensions.AspNetCore, opened up for inheritance, extension (#428)
 - Added Encode(T) and Encode(Type, object) to JwtBuilder (#415)
 - Updated Newtonsoft.Json to version 13.0.1
 - Fixed typos in exception messages
-- Made verify=true by default in IJwtDecoder methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 # 10.0.0
 
+- **Breaking:** System.Text.Json is now the default serializer
 - Made NoneAlgorithm not requiring any keys as it is not signed
 - Added option to select default serializer, Newtonsoft.Json or System.Text.Json (#433)
 - Renamed default IdentityFactory in Jwt.Extensions.AspNetCore, opened up for inheritance, extension (#428)


### PR DESCRIPTION
Changing the default serializer is a breaking change and should be explicitly called out.

We were hit by outages in production because while I had carefully reviewed the changelog, this particular change was not mentioned, and therefore not tested. (Shame on us for not having a sufficiently comprehensive test suite to catch this, of course.)