### PR TITLE
Made ctor of ValidationParameters public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 10.1.1
 
-- Updated ValidationParameters to allow instantiation; all validation mechanisms default to true but can be modified
+- Made ctor of ValidationParameters public, set default values for boolean properties to true
 
 # 10.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 10.1.1
+
+- Updated ValidationParameters to allow instantiation; all validation mechanisms default to true but can be modified
+
 # 10.1.0
 
 - Unmarked HMAC SHA based algorithms as insecure and obsolete (was done in 9.0.0-beta4)

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>10.1.0</Version>
+    <Version>10.1.1</Version>
     <FileVersion>10.0.0.0</FileVersion>
     <AssemblyVersion>10.0.0.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/JWT/ValidationParameters.cs
+++ b/src/JWT/ValidationParameters.cs
@@ -8,6 +8,7 @@ namespace JWT
     public class ValidationParameters
     {
         /// <remarks>
+        /// By default, all peroperties are set to <see langword="true" /> to ensure validation
         /// Use <see cref="Default"/> if you'd like to set all properties set to <see langword="true" />
         /// or use <see cref="None"/> if you'd like to set all properties set to <see langword="false" />.
         /// </remarks>>
@@ -18,33 +19,27 @@ namespace JWT
         /// <summary>
         /// Gets or sets whether to validate the validity of the token's signature.
         /// </summary>
-        public bool ValidateSignature { get; set; }
+        public bool ValidateSignature { get; set; } = true;
 
         /// <summary>
         /// Gets or sets whether to validate the validity of the token's expiration time.
         /// </summary>
-        public bool ValidateExpirationTime { get; set; }
+        public bool ValidateExpirationTime { get; set; } = true;
 
         /// <summary>
         /// Gets or sets whether to validate the validity of the token's issued time.
         /// </summary>
-        public bool ValidateIssuedTime { get; set; }
+        public bool ValidateIssuedTime { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the time margin in seconds for exp and nbf during token validation.
         /// </summary>
-        public int TimeMargin { get; set; }
+        public int TimeMargin { get; set; } = 0;
 
         /// <summary>
         /// Returns a <see cref="ValidationParameters" /> with all properties set to <see langword="true" />.
         /// </summary>
-        public static ValidationParameters Default => new ValidationParameters
-        {
-            ValidateSignature = true,
-            ValidateExpirationTime = true,
-            ValidateIssuedTime = true,
-            TimeMargin = 0
-        };
+        public static ValidationParameters Default => new ValidationParameters();
 
         /// <summary>
         /// Returns a <see cref="ValidationParameters" /> with all properties set to <see langword="false" />.

--- a/src/JWT/ValidationParameters.cs
+++ b/src/JWT/ValidationParameters.cs
@@ -11,7 +11,7 @@ namespace JWT
         /// Use <see cref="Default"/> if you'd like to set all properties set to <see langword="true" />
         /// or use <see cref="None"/> if you'd like to set all properties set to <see langword="false" />.
         /// </remarks>>
-        private ValidationParameters()
+        public ValidationParameters()
         {
         }
 

--- a/src/JWT/ValidationParameters.cs
+++ b/src/JWT/ValidationParameters.cs
@@ -8,7 +8,7 @@ namespace JWT
     public class ValidationParameters
     {
         /// <remarks>
-        /// By default, all peroperties are set to <see langword="true" /> to ensure validation
+        /// By default, all peroperties are set to <c>true</c> to ensure validation is enabled.
         /// Use <see cref="Default"/> if you'd like to set all properties set to <see langword="true" />
         /// or use <see cref="None"/> if you'd like to set all properties set to <see langword="false" />.
         /// </remarks>>

--- a/src/JWT/ValidationParameters.cs
+++ b/src/JWT/ValidationParameters.cs
@@ -34,7 +34,7 @@ namespace JWT
         /// <summary>
         /// Gets or sets the time margin in seconds for exp and nbf during token validation.
         /// </summary>
-        public int TimeMargin { get; set; } = 0;
+        public int TimeMargin { get; set; }
 
         /// <summary>
         /// Returns a <see cref="ValidationParameters" /> with all properties set to <see langword="true" />.

--- a/tests/JWT.Tests.Common/JwtValidatorTests.cs
+++ b/tests/JWT.Tests.Common/JwtValidatorTests.cs
@@ -378,7 +378,73 @@ namespace JWT.Tests
                    .BeTrue("because token should be valid");
 
         }
-        
+
+        [TestMethod]
+        public void ValidationParameters_Ctor_Should_Set_All_Validation_To_True()
+        {
+            var validationParameters = new ValidationParameters();
+
+            validationParameters.ValidateSignature.Should()
+                .BeTrue("because ValidationParameters constructor should set ValidateSignature to true");
+            validationParameters.ValidateExpirationTime.Should()
+                .BeTrue("because ValidationParameters constructor should set ValidateExpirationTime to true");
+            validationParameters.ValidateIssuedTime.Should()
+                .BeTrue("because ValidationParameters constructor should set ValidateIssuedTime to true");
+            validationParameters.TimeMargin.Should()
+                .Be(0, "because ValidationParameters constructor should set TimeMargin to 0");
+        }
+
+        [TestMethod]
+        public void ValidationParameters_Ctor_Should_Allow_Default_Values_To_Be_Overriden()
+        {
+            var validationParameters = new ValidationParameters
+            {
+                ValidateSignature = false,
+                ValidateExpirationTime = false,
+                ValidateIssuedTime = false,
+                TimeMargin = 300
+            };
+
+            validationParameters.ValidateSignature.Should()
+                .BeFalse("because ValidationParameters constructor should allow ValidateSignature to be overridden");
+            validationParameters.ValidateExpirationTime.Should()
+                .BeFalse("because ValidationParameters constructor should allow ValidateExpirationTime to be overridden");
+            validationParameters.ValidateIssuedTime.Should()
+                .BeFalse("because ValidationParameters constructor should allow ValidateIssuedTime to be overridden");
+            validationParameters.TimeMargin.Should()
+                .Be(300, "because ValidationParameters constructor should allow TimeMargin to be overridden");
+        }
+
+        [TestMethod]
+        public void ValidationParameters_Default_Should_Set_All_Validation_To_True()
+        {
+            var validationParameters = ValidationParameters.Default;
+
+            validationParameters.ValidateSignature.Should()
+                .BeTrue("because ValidationParameters.Default should set ValidateSignature to true");
+            validationParameters.ValidateExpirationTime.Should()
+                .BeTrue("because ValidationParameters.Default should set ValidateExpirationTime to true");
+            validationParameters.ValidateIssuedTime.Should()
+                .BeTrue("because ValidationParameters.Default should set ValidateIssuedTime to true");
+            validationParameters.TimeMargin.Should()
+                .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
+        }
+
+        [TestMethod]
+        public void ValidationParameters_None_Should_Set_All_Validation_To_False()
+        {
+            var validationParameters = ValidationParameters.None;
+
+            validationParameters.ValidateSignature.Should()
+                .BeFalse("because ValidationParameters.None should set ValidateSignature to false");
+            validationParameters.ValidateExpirationTime.Should()
+                .BeFalse("because ValidationParameters.DefaNoneult should set ValidateExpirationTime to false");
+            validationParameters.ValidateIssuedTime.Should()
+                .BeFalse("because ValidationParameters.None should set ValidateIssuedTime to false");
+            validationParameters.TimeMargin.Should()
+                .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
+        }
+
         private static IJsonSerializer CreateSerializer() =>
             new DefaultJsonSerializerFactory().Create();
     }

--- a/tests/JWT.Tests.Common/JwtValidatorTests.cs
+++ b/tests/JWT.Tests.Common/JwtValidatorTests.cs
@@ -382,22 +382,22 @@ namespace JWT.Tests
         [TestMethod]
         public void ValidationParameters_Ctor_Should_Set_All_Validation_To_True()
         {
-            var validationParameters = new ValidationParameters();
+            var valParams = new ValidationParameters();
 
-            validationParameters.ValidateSignature.Should()
-                .BeTrue("because ValidationParameters constructor should set ValidateSignature to true");
-            validationParameters.ValidateExpirationTime.Should()
-                .BeTrue("because ValidationParameters constructor should set ValidateExpirationTime to true");
-            validationParameters.ValidateIssuedTime.Should()
-                .BeTrue("because ValidationParameters constructor should set ValidateIssuedTime to true");
-            validationParameters.TimeMargin.Should()
-                .Be(0, "because ValidationParameters constructor should set TimeMargin to 0");
+            valParams.ValidateSignature.Should()
+                     .BeTrue("because ValidationParameters constructor should set ValidateSignature to true");
+            valParams.ValidateExpirationTime.Should()
+                     .BeTrue("because ValidationParameters constructor should set ValidateExpirationTime to true");
+            valParams.ValidateIssuedTime.Should()
+                     .BeTrue("because ValidationParameters constructor should set ValidateIssuedTime to true");
+            valParams.TimeMargin.Should()
+                     .Be(0, "because ValidationParameters constructor should set TimeMargin to 0");
         }
 
         [TestMethod]
         public void ValidationParameters_Ctor_Should_Allow_Default_Values_To_Be_Overriden()
         {
-            var validationParameters = new ValidationParameters
+            var valParams = new ValidationParameters
             {
                 ValidateSignature = false,
                 ValidateExpirationTime = false,
@@ -405,44 +405,44 @@ namespace JWT.Tests
                 TimeMargin = 300
             };
 
-            validationParameters.ValidateSignature.Should()
-                .BeFalse("because ValidationParameters constructor should allow ValidateSignature to be overridden");
-            validationParameters.ValidateExpirationTime.Should()
-                .BeFalse("because ValidationParameters constructor should allow ValidateExpirationTime to be overridden");
-            validationParameters.ValidateIssuedTime.Should()
-                .BeFalse("because ValidationParameters constructor should allow ValidateIssuedTime to be overridden");
-            validationParameters.TimeMargin.Should()
-                .Be(300, "because ValidationParameters constructor should allow TimeMargin to be overridden");
+            valParams.ValidateSignature.Should()
+                     .BeFalse("because ValidationParameters constructor should allow ValidateSignature to be overridden");
+            valParams.ValidateExpirationTime.Should()
+                     .BeFalse("because ValidationParameters constructor should allow ValidateExpirationTime to be overridden");
+            valParams.ValidateIssuedTime.Should()
+                     .BeFalse("because ValidationParameters constructor should allow ValidateIssuedTime to be overridden");
+            valParams.TimeMargin.Should()
+                     .Be(300, "because ValidationParameters constructor should allow TimeMargin to be overridden");
         }
 
         [TestMethod]
         public void ValidationParameters_Default_Should_Set_All_Validation_To_True()
         {
-            var validationParameters = ValidationParameters.Default;
+            var valParams = ValidationParameters.Default;
 
-            validationParameters.ValidateSignature.Should()
-                .BeTrue("because ValidationParameters.Default should set ValidateSignature to true");
-            validationParameters.ValidateExpirationTime.Should()
-                .BeTrue("because ValidationParameters.Default should set ValidateExpirationTime to true");
-            validationParameters.ValidateIssuedTime.Should()
-                .BeTrue("because ValidationParameters.Default should set ValidateIssuedTime to true");
-            validationParameters.TimeMargin.Should()
-                .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
+            valParams.ValidateSignature.Should()
+                     .BeTrue("because ValidationParameters.Default should set ValidateSignature to true");
+            valParams.ValidateExpirationTime.Should()
+                     .BeTrue("because ValidationParameters.Default should set ValidateExpirationTime to true");
+            valParams.ValidateIssuedTime.Should()
+                     .BeTrue("because ValidationParameters.Default should set ValidateIssuedTime to true");
+            valParams.TimeMargin.Should()
+                     .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
         }
 
         [TestMethod]
         public void ValidationParameters_None_Should_Set_All_Validation_To_False()
         {
-            var validationParameters = ValidationParameters.None;
+            var valParams = ValidationParameters.None;
 
-            validationParameters.ValidateSignature.Should()
-                .BeFalse("because ValidationParameters.None should set ValidateSignature to false");
-            validationParameters.ValidateExpirationTime.Should()
-                .BeFalse("because ValidationParameters.DefaNoneult should set ValidateExpirationTime to false");
-            validationParameters.ValidateIssuedTime.Should()
-                .BeFalse("because ValidationParameters.None should set ValidateIssuedTime to false");
-            validationParameters.TimeMargin.Should()
-                .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
+            valParams.ValidateSignature.Should()
+                     .BeFalse("because ValidationParameters.None should set ValidateSignature to false");
+            valParams.ValidateExpirationTime.Should()
+                     .BeFalse("because ValidationParameters.DefaNoneult should set ValidateExpirationTime to false");
+            valParams.ValidateIssuedTime.Should()
+                     .BeFalse("because ValidationParameters.None should set ValidateIssuedTime to false");
+            valParams.TimeMargin.Should()
+                     .Be(0, "because ValidationParameters.Default should set TimeMargin to 0");
         }
 
         private static IJsonSerializer CreateSerializer() =>


### PR DESCRIPTION
The constructor for ValidationParameters was private, which produces compile errors for the examples on the main page and prevents them from being used (https://github.com/jwt-dotnet/jwt#turning-off-parts-of-token-validation, https://github.com/jwt-dotnet/jwt#or-using-the-fluent-builder-api-4). Making the constructor public makes them valid. It's possible to use the "With" method and the "Default" or "None" properties, but it is cumbersome.