### PR TITLE
Refactor null checks with 'is not null' in JwtBuilder

### DIFF
--- a/src/JWT/Algorithms/ECDSAAlgorithmFactory.cs
+++ b/src/JWT/Algorithms/ECDSAAlgorithmFactory.cs
@@ -73,15 +73,15 @@ namespace JWT.Algorithms
 #if NETSTANDARD2_0 || NET6_0_OR_GREATER
         private IJwtAlgorithm CreateES256Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new ES256Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new ES256Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new ES256Algorithm(_publicKey);
             }
@@ -91,15 +91,15 @@ namespace JWT.Algorithms
 
         private IJwtAlgorithm CreateES384Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new ES384Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new ES384Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new ES384Algorithm(_publicKey);
             }
@@ -109,15 +109,15 @@ namespace JWT.Algorithms
 
         private IJwtAlgorithm CreateES512Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new ES512Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new ES512Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new ES512Algorithm(_publicKey);
             }

--- a/src/JWT/Algorithms/RSAlgorithmFactory.cs
+++ b/src/JWT/Algorithms/RSAlgorithmFactory.cs
@@ -65,15 +65,15 @@ namespace JWT.Algorithms
 
         private RS256Algorithm CreateRS256Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS256Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS256Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS256Algorithm(_publicKey);
             }
@@ -83,15 +83,15 @@ namespace JWT.Algorithms
 
         private RS384Algorithm CreateRS384Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS384Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS384Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS384Algorithm(_publicKey);
             }
@@ -101,15 +101,15 @@ namespace JWT.Algorithms
 
         private RS512Algorithm CreateRS512Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS512Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS512Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS512Algorithm(_publicKey);
             }
@@ -119,15 +119,15 @@ namespace JWT.Algorithms
 
         private RS1024Algorithm CreateRS1024Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS1024Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS1024Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS1024Algorithm(_publicKey);
             }
@@ -137,15 +137,15 @@ namespace JWT.Algorithms
 
         private RS2048Algorithm CreateRS2048Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS2048Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS2048Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS2048Algorithm(_publicKey);
             }
@@ -155,15 +155,15 @@ namespace JWT.Algorithms
 
         private RS4096Algorithm CreateRS4096Algorithm()
         {
-            if (_certFactory is object)
+            if (_certFactory is not null)
             {
                 return new RS4096Algorithm(_certFactory());
             }
-            if (_publicKey is object && _privateKey is object)
+            if (_publicKey is not null && _privateKey is not null)
             {
                 return new RS4096Algorithm(_publicKey, _privateKey);
             }
-            if (_publicKey is object)
+            if (_publicKey is not null)
             {
                 return new RS4096Algorithm(_publicKey);
             }

--- a/src/JWT/Builder/JwtBuilder.cs
+++ b/src/JWT/Builder/JwtBuilder.cs
@@ -348,9 +348,9 @@ namespace JWT.Builder
             if (_urlEncoder is null)
                 throw new InvalidOperationException($"Can't instantiate {nameof(JwtEncoder)}. Call {nameof(WithUrlEncoder)}.");
 
-            if (_algorithm is object)
+            if (_algorithm is not null)
                 _encoder = new JwtEncoder(_algorithm, jsonSerializer, _urlEncoder);
-            else if (_algFactory is object)
+            else if (_algFactory is not null)
                 _encoder = new JwtEncoder(_algFactory, jsonSerializer, _urlEncoder);
         }
 
@@ -364,9 +364,9 @@ namespace JWT.Builder
             if (_urlEncoder is null)
                 throw new InvalidOperationException($"Can't instantiate {nameof(JwtDecoder)}. Call {nameof(WithUrlEncoder)}.");
 
-            if (_algorithm is object)
+            if (_algorithm is not null)
                 _decoder = new JwtDecoder(jsonSerializer, _validator, _urlEncoder, _algorithm);
-            else if (_algFactory is object)
+            else if (_algFactory is not null)
                 _decoder = new JwtDecoder(jsonSerializer, _validator, _urlEncoder, _algFactory);
             else if (!_valParams.ValidateSignature)
                 _decoder = new JwtDecoder(jsonSerializer, _urlEncoder);
@@ -385,7 +385,7 @@ namespace JWT.Builder
 
         private void TryCreateValidator()
         {
-            if (_validator is object)
+            if (_validator is not null)
                 return;
 
             var jsonSerializer = _jsonSerializerFactory.Create();
@@ -445,10 +445,10 @@ namespace JWT.Builder
         /// Checks whether enough dependencies were supplied to encode a new token.
         /// </summary>
         private bool CanEncode() =>
-            (_algorithm is object || _algFactory is object) &&
-            _jsonSerializerFactory is object &&
-            _urlEncoder is object &&
-            _jwt.Payload is object;
+            (_algorithm is not null || _algFactory is not null) &&
+            _jsonSerializerFactory is not null &&
+            _urlEncoder is not null &&
+            _jwt.Payload is not null;
 
         /// <summary>
         /// Checks whether enough dependencies were supplied to decode a token.
@@ -459,7 +459,7 @@ namespace JWT.Builder
                 return false;
 
             if (_valParams.ValidateSignature)
-                return _validator is object && (_algorithm is object || _algFactory is object);
+                return _validator is not null && (_algorithm is not null || _algFactory is not null);
 
             return true;
         }
@@ -469,10 +469,7 @@ namespace JWT.Builder
             if (_urlEncoder is null)
                 return false;
 
-            if (_jsonSerializerFactory is null)
-                return false;
-
-            return true;
+            return _jsonSerializerFactory is not null;
         }
 
         private string GetPropName(MemberInfo prop)

--- a/src/JWT/IJwtEncoder.cs
+++ b/src/JWT/IJwtEncoder.cs
@@ -34,7 +34,7 @@ namespace JWT
         /// <returns>The generated JWT</returns>
         /// <exception cref="ArgumentNullException" />
         public static string Encode(this IJwtEncoder encoder, object payload, string key) =>
-            encoder.Encode(null, payload, key is object ? GetBytes(key) : null);
+            encoder.Encode(null, payload, key is not null ? GetBytes(key) : null);
 
         /// <summary>
         /// Creates a JWT given a payload, the signing key, and the algorithm to use.

--- a/src/JWT/JwtValidator.cs
+++ b/src/JWT/JwtValidator.cs
@@ -73,7 +73,7 @@ namespace JWT
         public void Validate(string decodedPayload, string signature, params string[] decodedSignatures)
         {
             var ex = GetValidationException(decodedPayload, signature, decodedSignatures);
-            if (ex is object)
+            if (ex is not null)
                 throw ex;
         }
 
@@ -83,7 +83,7 @@ namespace JWT
         public void Validate(string decodedPayload, IAsymmetricAlgorithm alg, byte[] bytesToSign, byte[] decodedSignature)
         {
             var ex = GetValidationException(alg, decodedPayload, bytesToSign, decodedSignature);
-            if (ex is object)
+            if (ex is not null)
                 throw ex;
         }
 


### PR DESCRIPTION
To better follow the naming convention and improve code readability, the null checks in JwtBuilder.cs have been updated from `is object` to `is not null`.