### PR TITLE
Made events async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # JWT.Extensions.AspNetCore 11.0.0-beta4
 
-- Makes the event model support async await
+- Make the event model support async-await
 
 # JWT.Extensions.AspNetCore 11.0.0-beta3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# JWT.Extensions.AspNetCore 11.0.0-beta4
+
+- Makes the event model support async await
+
 # JWT.Extensions.AspNetCore 11.0.0-beta3
 
 - Converted to use the event model to allow dependency injection with custom event classes.

--- a/src/JWT.Extensions.AspNetCore/JWT.Extensions.AspNetCore.csproj
+++ b/src/JWT.Extensions.AspNetCore/JWT.Extensions.AspNetCore.csproj
@@ -10,7 +10,7 @@
     <Authors>Alexander Batishchev</Authors>
     <PackageTags>jwt;json;asp.net;asp.net core;.net core;authorization</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>11.0.0-beta3</Version>
+    <Version>11.0.0-beta4</Version>
     <FileVersion>11.0.0.0</FileVersion>
     <AssemblyVersion>11.0.0.0</AssemblyVersion>
     <RootNamespace>JWT.Extensions.AspNetCore</RootNamespace>

--- a/src/JWT.Extensions.AspNetCore/JwtAuthenticationEvents.cs
+++ b/src/JWT.Extensions.AspNetCore/JwtAuthenticationEvents.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -41,47 +42,47 @@ namespace JWT.Extensions.AspNetCore
                 "Error decoding JWT: {0}, returning failure");
         }
 
-        public Func<ILogger, AuthenticateResult> OnMissingHeader { get; set; } =
+        public Func<ILogger, Task<AuthenticateResult>> OnMissingHeader { get; set; } =
             logger =>
             {
                 _logMissingHeader(logger, null);
-                return AuthenticateResult.NoResult();
+                return Task.FromResult(AuthenticateResult.NoResult());
             };
 
-        public Func<ILogger, string, string, AuthenticateResult> OnIncorrectScheme { get; set; } =
+        public Func<ILogger, string, string, Task<AuthenticateResult>> OnIncorrectScheme { get; set; } =
             (logger, actualScheme, expectedScheme) =>
             {
                 _logIncorrectScheme(logger, actualScheme, expectedScheme, null);
-                return AuthenticateResult.NoResult();
+                return Task.FromResult(AuthenticateResult.NoResult());
             };
 
-        public Func<ILogger, string, AuthenticateResult> OnEmptyHeader { get; set; } = (logger, header) =>
+        public Func<ILogger, string, Task<AuthenticateResult>> OnEmptyHeader { get; set; } = (logger, header) =>
         {
             _logEmptyHeader(logger, null);
-            return AuthenticateResult.NoResult();
+            return Task.FromResult(AuthenticateResult.NoResult());
         };
 
-        public Func<SuccessfulTicketContext, AuthenticateResult> OnSuccessfulTicket { get; set; } = context =>
+        public Func<SuccessfulTicketContext, Task<AuthenticateResult>> OnSuccessfulTicket { get; set; } = context =>
         {
             _logSuccessfulTicket(context.Logger, null);
-            return AuthenticateResult.Success(context.Ticket);
+            return Task.FromResult(AuthenticateResult.Success(context.Ticket));
         };
 
-        public Func<FailedTicketContext, AuthenticateResult> OnFailedTicket { get; set; } = context =>
+        public Func<FailedTicketContext, Task<AuthenticateResult>> OnFailedTicket { get; set; } = context =>
         {
             _logFailedTicket(context.Logger, context.Exception.Message, context.Exception);
-            return AuthenticateResult.Fail(context.Exception);
+            return Task.FromResult(AuthenticateResult.Fail(context.Exception));
         };
 
-        public virtual AuthenticateResult SuccessfulTicket(SuccessfulTicketContext context) => OnSuccessfulTicket(context);
+        public virtual Task<AuthenticateResult> SuccessfulTicket(SuccessfulTicketContext context) => OnSuccessfulTicket(context);
 
-        public virtual AuthenticateResult FailedTicket(FailedTicketContext context) => OnFailedTicket(context);
+        public virtual Task<AuthenticateResult> FailedTicket(FailedTicketContext context) => OnFailedTicket(context);
 
-        public virtual AuthenticateResult EmptyHeader(ILogger logger, string header) => OnEmptyHeader(logger, header);
+        public virtual Task<AuthenticateResult> EmptyHeader(ILogger logger, string header) => OnEmptyHeader(logger, header);
 
-        public virtual AuthenticateResult IncorrectScheme(ILogger logger, string actualScheme, string expectedScheme) => OnIncorrectScheme(logger, actualScheme, expectedScheme);
+        public virtual Task<AuthenticateResult> IncorrectScheme(ILogger logger, string actualScheme, string expectedScheme) => OnIncorrectScheme(logger, actualScheme, expectedScheme);
 
-        public virtual AuthenticateResult MissingHeader(ILogger logger) => OnMissingHeader(logger);
+        public virtual Task<AuthenticateResult> MissingHeader(ILogger logger) => OnMissingHeader(logger);
 
     }
 }

--- a/src/JWT.Extensions.AspNetCore/JwtAuthenticationHandler.cs
+++ b/src/JWT.Extensions.AspNetCore/JwtAuthenticationHandler.cs
@@ -35,10 +35,10 @@ namespace JWT.Extensions.AspNetCore
         {
             var header = this.Context.Request.Headers[HeaderNames.Authorization];
             var result = GetAuthenticationResult(header);
-            return Task.FromResult(result);
+            return result;
         }
 
-        private AuthenticateResult GetAuthenticationResult(string header)
+        private Task<AuthenticateResult> GetAuthenticationResult(string header)
         {
             if (String.IsNullOrEmpty(header))
                 return this.Events.MissingHeader(this.Logger);

--- a/src/JWT.Extensions.AspNetCore/JwtAuthenticationOptions.cs
+++ b/src/JWT.Extensions.AspNetCore/JwtAuthenticationOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
@@ -36,8 +37,11 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnMissingHeader")]
         public Func<ILogger, AuthenticateResult> OnMissingHeader
         {
-            get => Events.OnMissingHeader;
-            set => Events.OnMissingHeader = value;
+            set => Events.OnMissingHeader = (logger) =>
+            {
+                var result = value.Invoke(logger);
+                return Task.FromResult(result);
+            };
         }
 
         /// <summary>
@@ -49,8 +53,11 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnIncorrectScheme")]
         public Func<ILogger, string, string, AuthenticateResult> OnIncorrectScheme
         {
-            get => Events.OnIncorrectScheme;
-            set => Events.OnIncorrectScheme = value;
+            set => Events.OnIncorrectScheme = (logger, actualScheme, expectedScheme) =>
+            {
+                var result = value.Invoke(logger, actualScheme, expectedScheme);
+                return Task.FromResult(result);
+            };
         }
 
         /// <summary>
@@ -62,8 +69,11 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnEmptyHeader")]
         public Func<ILogger, string, AuthenticateResult> OnEmptyHeader
         {
-            get => Events.OnEmptyHeader;
-            set => Events.OnEmptyHeader = value;
+            set => Events.OnEmptyHeader = (logger, header) =>
+            {
+                var result = value.Invoke(logger, header);
+                return Task.FromResult(result);
+            };
         }
 
         /// <summary>
@@ -75,7 +85,11 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnSuccessfulTicket")]
         public Func<ILogger, AuthenticationTicket, AuthenticateResult> OnSuccessfulTicket
         {
-            set => Events.OnSuccessfulTicket = (context) => value(context.Logger, context.Ticket);
+            set => Events.OnSuccessfulTicket = (context) =>
+            {
+                var result = value(context.Logger, context.Ticket);
+                return Task.FromResult(result);
+            };
         }
 
         /// <summary>
@@ -87,7 +101,11 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnFailedTicket")]
         public Func<ILogger, Exception, AuthenticateResult> OnFailedTicket
         {
-            set => Events.OnFailedTicket = context => value(context.Logger, context.Exception);
+            set => Events.OnFailedTicket = (context) =>
+            {
+                var result = value(context.Logger, context.Exception);
+                return Task.FromResult(result);
+            };
         }
 
         /// <summary>

--- a/src/JWT.Extensions.AspNetCore/JwtAuthenticationOptions.cs
+++ b/src/JWT.Extensions.AspNetCore/JwtAuthenticationOptions.cs
@@ -37,7 +37,7 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnMissingHeader")]
         public Func<ILogger, AuthenticateResult> OnMissingHeader
         {
-            set => Events.OnMissingHeader = (logger) =>
+            set => Events.OnMissingHeader = logger =>
             {
                 var result = value.Invoke(logger);
                 return Task.FromResult(result);
@@ -85,7 +85,7 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnSuccessfulTicket")]
         public Func<ILogger, AuthenticationTicket, AuthenticateResult> OnSuccessfulTicket
         {
-            set => Events.OnSuccessfulTicket = (context) =>
+            set => Events.OnSuccessfulTicket = context =>
             {
                 var result = value(context.Logger, context.Ticket);
                 return Task.FromResult(result);
@@ -101,7 +101,7 @@ namespace JWT.Extensions.AspNetCore
         [Obsolete("Use Events.OnFailedTicket")]
         public Func<ILogger, Exception, AuthenticateResult> OnFailedTicket
         {
-            set => Events.OnFailedTicket = (context) =>
+            set => Events.OnFailedTicket = context =>
             {
                 var result = value(context.Logger, context.Exception);
                 return Task.FromResult(result);

--- a/tests/JWT.Extensions.AspNetCore.Tests/JwtAuthenticationEventsIntegrationTests.cs
+++ b/tests/JWT.Extensions.AspNetCore.Tests/JwtAuthenticationEventsIntegrationTests.cs
@@ -136,7 +136,7 @@ namespace JWT.Extensions.AspNetCore.Tests
             public MyEvents(MyEventsDependency dependency) =>
                 _dependency = dependency;
 
-            public override AuthenticateResult SuccessfulTicket(SuccessfulTicketContext context)
+            public override Task<AuthenticateResult> SuccessfulTicket(SuccessfulTicketContext context)
             {
                 _dependency.Set();
                 return base.SuccessfulTicket(context);


### PR DESCRIPTION
## Description

I was integrating the beta build into my project and noticed that I failed to make the events async/await able. This is preventing me from digging into my database to verify attributes about the JWT token in my custom Event Type.

I was careful to avoid doing any actual awaits in the framework to try and minimize the amount of "task switching" that the internal framework is doing.  

## Checklist

- [x] Tests added
- [x] Version bumped
- [x] Changelog updated
