### PR TITLE
Make CI build deterministic

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -55,7 +55,7 @@ steps:
   inputs:
     command: build
     projects: ${{ parameters.solutionName }}
-    arguments: '-c ${{ parameters.buildConfiguration }} --no-restore'
+    arguments: '-c ${{ parameters.buildConfiguration }} --no-restore -p:ContinuousIntegrationBuild=true'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run tests'


### PR DESCRIPTION
## Description

Resolves #505 .

CI build is now configured with deterministic build flag. Artifacts contain nuget packages with proper flags:

![image](https://github.com/user-attachments/assets/6dafc77d-439b-49b8-be11-1fb4c8b88172)


## Checklist

- [ ] Tests added
- [ ] Version bumped
- [ ] Changelog updated
