### PR TITLE
Updated System.Text.Json to version 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# JWT 11.0.0
+
+- Updated System.Text.Json to version 9.0.0
+
 # JWT 11.0.0-beta3
 
 - Updated System.Text.Json to version 8.0.4

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>11.0.0-beta3</Version>
+    <Version>11.0.0</Version>
     <FileVersion>11.0.0.0</FileVersion>
     <AssemblyVersion>11.0.0.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/JWT/JWT.csproj
+++ b/src/JWT/JWT.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
@@ -66,6 +66,10 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded Nuget ref for System.Text.Json

[JsonExtensionData] is not used, but its annoying that there are vulnerabilities in refs

